### PR TITLE
Win32 include guards, clang-format

### DIFF
--- a/src/clean-core/allocate.hh
+++ b/src/clean-core/allocate.hh
@@ -2,8 +2,8 @@
 
 #include <cstddef>
 
-#include <clean-core/forward.hh>
 #include <clean-core/assert.hh>
+#include <clean-core/forward.hh>
 #include <clean-core/typedefs.hh>
 
 namespace cc

--- a/src/clean-core/array.hh
+++ b/src/clean-core/array.hh
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <clean-core/forward.hh>
 #include <clean-core/algorithms.hh>
 #include <clean-core/assert.hh>
-#include <clean-core/forward.hh>
 #include <clean-core/fwd.hh>
 #include <clean-core/span.hh>
 #include <clean-core/typedefs.hh>
@@ -50,16 +50,27 @@ struct array<T, dynamic_size>
 {
     array() = default;
 
-    explicit array(size_t size) : _data(new T[size]()), _size(size) {}
-    explicit array(size_t size, T* data) : _data(data), _size(size) {}
+    explicit array(size_t size)
+    {
+        _size = size;
+        _data = new T[_size](); // default ctor!
+    }
 
     [[nodiscard]] static array defaulted(size_t size) { return array(size); }
 
-    [[nodiscard]] static array uninitialized(size_t size) { return array(size, new T[size]); }
+    [[nodiscard]] static array uninitialized(size_t size)
+    {
+        array a;
+        a._size = size;
+        a._data = new T[size];
+        return a;
+    }
 
     [[nodiscard]] static array filled(size_t size, T const& value)
     {
-        array a(size, new T[size]);
+        array a;
+        a._size = size;
+        a._data = new T[size];
         cc::fill(a, value);
         return a;
     }

--- a/src/clean-core/array.hh
+++ b/src/clean-core/array.hh
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <clean-core/forward.hh>
 #include <clean-core/algorithms.hh>
 #include <clean-core/assert.hh>
+#include <clean-core/forward.hh>
 #include <clean-core/fwd.hh>
 #include <clean-core/span.hh>
 #include <clean-core/typedefs.hh>

--- a/src/clean-core/array.hh
+++ b/src/clean-core/array.hh
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <clean-core/forward.hh>
 #include <clean-core/algorithms.hh>
 #include <clean-core/assert.hh>
+#include <clean-core/forward.hh>
 #include <clean-core/fwd.hh>
 #include <clean-core/span.hh>
 #include <clean-core/typedefs.hh>
@@ -50,27 +50,16 @@ struct array<T, dynamic_size>
 {
     array() = default;
 
-    explicit array(size_t size)
-    {
-        _size = size;
-        _data = new T[_size](); // default ctor!
-    }
+    explicit array(size_t size) : _data(new T[size]()), _size(size) {}
+    explicit array(size_t size, T* data) : _data(data), _size(size) {}
 
     [[nodiscard]] static array defaulted(size_t size) { return array(size); }
 
-    [[nodiscard]] static array uninitialized(size_t size)
-    {
-        array a;
-        a._size = size;
-        a._data = new T[size];
-        return a;
-    }
+    [[nodiscard]] static array uninitialized(size_t size) { return array(size, new T[size]); }
 
     [[nodiscard]] static array filled(size_t size, T const& value)
     {
-        array a;
-        a._size = size;
-        a._data = new T[size];
+        array a(size, new T[size]);
         cc::fill(a, value);
         return a;
     }

--- a/src/clean-core/assert.cc
+++ b/src/clean-core/assert.cc
@@ -5,11 +5,11 @@
 
 namespace
 {
-using assertion_handler_t = void (*)(cc::detail::assertion_info const &);
+using assertion_handler_t = void (*)(cc::detail::assertion_info const&);
 
 thread_local assertion_handler_t s_current_handler = nullptr;
 
-void default_assertion_handler(cc::detail::assertion_info const &info)
+void default_assertion_handler(cc::detail::assertion_info const& info)
 {
     fprintf(stderr, "assertion `%s' failed.\n", info.expr);
     fprintf(stderr, "  in %s\n", info.func);
@@ -22,7 +22,7 @@ void default_assertion_handler(cc::detail::assertion_info const &info)
 }
 } // namespace
 
-void cc::detail::assertion_failed(assertion_info const &info)
+void cc::detail::assertion_failed(assertion_info const& info)
 {
     if (s_current_handler)
         s_current_handler(info);
@@ -30,4 +30,4 @@ void cc::detail::assertion_failed(assertion_info const &info)
         default_assertion_handler(info);
 }
 
-void cc::set_assertion_handler(void (*handler)(detail::assertion_info const &)) { s_current_handler = handler; }
+void cc::set_assertion_handler(void (*handler)(detail::assertion_info const&)) { s_current_handler = handler; }

--- a/src/clean-core/cursor.hh
+++ b/src/clean-core/cursor.hh
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <clean-core/move.hh>
 #include <clean-core/assert.hh>
+#include <clean-core/move.hh>
 
 namespace cc
 {

--- a/src/clean-core/invoke.hh
+++ b/src/clean-core/invoke.hh
@@ -2,8 +2,8 @@
 
 #include <type_traits>
 
-#include <clean-core/forward.hh>
 #include <clean-core/detail/reference_wrapper.hh>
+#include <clean-core/forward.hh>
 
 namespace cc
 {

--- a/src/clean-core/native/win32_sanitized.hh
+++ b/src/clean-core/native/win32_sanitized.hh
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <clean-core/macros.hh>
+#ifdef CC_OS_WINDOWS
+
 // Check if <Windows.h> was included somewhere before this header
 #if defined(_WINDOWS_) && !defined(CC_SANITIZED_WINDOWS_H)
 #pragma message("Including unsanitized Windows.h")
@@ -37,7 +40,8 @@
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-    THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 #define NOGDICAPMASKS // CC_*, LC_*, PC_*, CP_*, TC_*, RC_
@@ -132,3 +136,5 @@ struct IUnknown;
 #undef GetClassInfo
 #undef Yield
 #undef IMediaEventSink
+
+#endif

--- a/src/clean-core/optional.hh
+++ b/src/clean-core/optional.hh
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <clean-core/forward.hh>
 #include <clean-core/always_false.hh>
 #include <clean-core/assert.hh>
+#include <clean-core/forward.hh>
 #include <clean-core/fwd.hh>
 #include <clean-core/storage.hh>
 

--- a/src/clean-core/poly_unique_ptr.hh
+++ b/src/clean-core/poly_unique_ptr.hh
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <clean-core/forward.hh>
 #include <clean-core/always_false.hh>
 #include <clean-core/assert.hh>
+#include <clean-core/forward.hh>
 #include <clean-core/fwd.hh>
 #include <clean-core/typedefs.hh>
 


### PR DESCRIPTION
- Add include guards to `win32_sanitized.hh` in order not to trip up IDEs and arcana linter
- Run clang-format on all files