### PR TITLE
Kw/develop

### DIFF
--- a/src/clean-core/allocate.hh
+++ b/src/clean-core/allocate.hh
@@ -4,6 +4,7 @@
 
 #include <clean-core/assert.hh>
 #include <clean-core/forward.hh>
+#include <clean-core/new.hh>
 #include <clean-core/typedefs.hh>
 
 namespace cc
@@ -136,7 +137,7 @@ template <class T, class... Args>
 T* alloc(Args&&... args)
 {
     auto p = detail::get_pool_allocator<sizeof(T), alignof(T)>().alloc();
-    new (p) T(cc::forward<Args>(args)...);
+    new (cc::placement_new, p) T(cc::forward<Args>(args)...);
     return reinterpret_cast<T*>(p);
 }
 template <class T>

--- a/src/clean-core/capped_array.hh
+++ b/src/clean-core/capped_array.hh
@@ -155,7 +155,7 @@ public:
 
     // members
 private:
-    using compact_size_t = detail::compact_size_t_for<N, alignof(T)>;
+    using compact_size_t = detail::compact_size_t_typed<T, N>;
 
     compact_size_t _size = 0;
     storage_for<T[N]> _u;

--- a/src/clean-core/capped_vector.hh
+++ b/src/clean-core/capped_vector.hh
@@ -237,7 +237,7 @@ public:
     }
 
 private:
-    using compact_size_t = detail::compact_size_t_for<N, alignof(T)>;
+    using compact_size_t = detail::compact_size_t_typed<T, N>;
 
     compact_size_t _size = 0;
     storage_for<T[N]> _u;

--- a/src/clean-core/detail/compact_size_t.hh
+++ b/src/clean-core/detail/compact_size_t.hh
@@ -24,7 +24,7 @@ using compact_size_t_for = decltype(helper_size_t<N, Alignment>());
 /// Indirection workaround for a current MSVC compiler bug (19.22)
 /// without indirection: https://godbolt.org/z/iQ19yj
 /// with indirection: https://godbolt.org/z/6MoWE4
-/// Did not yet report this to Microsoft
-template<class T, size_t N>
+/// Bug report: https://developercommunity.visualstudio.com/content/problem/800899/false-positive-for-c2975-on-alias-template-fixed-w.html
+template <class T, size_t N>
 using compact_size_t_typed = compact_size_t_for<N, alignof(T)>;
 }

--- a/src/clean-core/detail/compact_size_t.hh
+++ b/src/clean-core/detail/compact_size_t.hh
@@ -20,4 +20,11 @@ auto helper_size_t()
 
 template <size_t N, size_t Alignment>
 using compact_size_t_for = decltype(helper_size_t<N, Alignment>());
+
+/// Indirection workaround for a current MSVC compiler bug (19.22)
+/// without indirection: https://godbolt.org/z/iQ19yj
+/// with indirection: https://godbolt.org/z/6MoWE4
+/// Did not yet report this to Microsoft
+template<class T, size_t N>
+using compact_size_t_typed = compact_size_t_for<N, alignof(T)>;
 }

--- a/src/clean-core/native/win32_fwd.hh
+++ b/src/clean-core/native/win32_fwd.hh
@@ -1,0 +1,14 @@
+#pragma once
+
+// Common Win32 entities forward declared
+// NOTE: This header might cause conflicts if using Microsoft SAL code analysis tools
+// See https://docs.microsoft.com/en-us/cpp/c-runtime-library/sal-annotations?redirectedfrom=MSDN&view=vs-2019
+
+typedef unsigned long DWORD;
+typedef const wchar_t* LPCWSTR;
+typedef void* HANDLE;
+typedef struct HINSTANCE__* HINSTANCE;
+typedef struct HWND__* HWND;
+typedef struct HMONITOR__* HMONITOR;
+typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
+typedef long HRESULT;

--- a/src/clean-core/native/win32_fwd.hh
+++ b/src/clean-core/native/win32_fwd.hh
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <clean-core/macros.hh>
+#ifdef CC_OS_WINDOWS
+
 // Common Win32 entities forward declared
 // NOTE: This header might cause conflicts if using Microsoft SAL code analysis tools
 // See https://docs.microsoft.com/en-us/cpp/c-runtime-library/sal-annotations?redirectedfrom=MSDN&view=vs-2019
@@ -12,3 +15,5 @@ typedef struct HWND__* HWND;
 typedef struct HMONITOR__* HMONITOR;
 typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
 typedef long HRESULT;
+
+#endif

--- a/src/clean-core/utility.hh
+++ b/src/clean-core/utility.hh
@@ -3,13 +3,13 @@
 namespace cc
 {
 template <class T>
-const T& max(const T& a, const T& b)
+constexpr T const& max(const T& a, const T& b)
 {
     return (a < b) ? b : a;
 }
 
 template <class T>
-const T& min(const T& a, const T& b)
+constexpr T const& min(const T& a, const T& b)
 {
     return (a < b) ? a : b;
 }

--- a/src/clean-core/utility.hh
+++ b/src/clean-core/utility.hh
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace cc
+{
+template <class T>
+const T& max(const T& a, const T& b)
+{
+    return (a < b) ? b : a;
+}
+
+template <class T>
+const T& min(const T& a, const T& b)
+{
+    return (a < b) ? a : b;
+}
+}

--- a/src/clean-core/utility.hh
+++ b/src/clean-core/utility.hh
@@ -3,13 +3,13 @@
 namespace cc
 {
 template <class T>
-constexpr T const& max(const T& a, const T& b)
+constexpr T const& max(T const& a, T const& b)
 {
     return (a < b) ? b : a;
 }
 
 template <class T>
-constexpr T const& min(const T& a, const T& b)
+constexpr T const& min(T const& a, T const& b)
 {
     return (a < b) ? a : b;
 }

--- a/src/clean-core/utility.hh
+++ b/src/clean-core/utility.hh
@@ -3,13 +3,13 @@
 namespace cc
 {
 template <class T>
-constexpr T const& max(T const& a, T const& b)
+[[nodiscard]] constexpr T const& max(T const& a, T const& b)
 {
     return (a < b) ? b : a;
 }
 
 template <class T>
-constexpr T const& min(T const& a, T const& b)
+[[nodiscard]] constexpr T const& min(T const& a, T const& b)
 {
     return (a < b) ? a : b;
 }


### PR DESCRIPTION
- Add `native/win32_fwd.hh`
- Add `utility.hh` with `cc::min`, `cc::max`
- Fix missing `cc::placement_new` in `cc::alloc`
- Add optimizations to `cc::vector` based on `T` being trivially copy-constructible or destructible
- Add indirection to `compact_size_t_for` as a workaround to a MSVC compiler bug
- Submitted the MSVC bug: https://developercommunity.visualstudio.com/content/problem/800899/false-positive-for-c2975-on-alias-template-fixed-w.html