### PR TITLE
Kw/develop

### DIFF
--- a/src/clean-core/array.hh
+++ b/src/clean-core/array.hh
@@ -7,8 +7,6 @@
 #include <clean-core/span.hh>
 #include <clean-core/typedefs.hh>
 
-#include <initializer_list>
-
 namespace cc
 {
 // compile-time fixed-size array
@@ -152,9 +150,8 @@ private:
 };
 
 // deduction guides
-// TODO: common range deduction guide
-template <class T>
-array(std::initializer_list<T>)->array<T>;
+template <class T, class... U>
+array(T, U...) -> array<T, 1 + sizeof...(U)>;
 
 template <class T, class... Args>
 [[nodiscard]] array<T, 1 + sizeof...(Args)> make_array(T&& v0, Args&&... rest)

--- a/src/clean-core/cursor.hh
+++ b/src/clean-core/cursor.hh
@@ -46,7 +46,7 @@ struct iterator_cursor : cursor<iterator_cursor<iterator_t, sentinel_t>>
 
     [[nodiscard]] constexpr decltype(auto) get() const
     {
-        //CC_CONTRACT(_curr != nullptr); // does not work with std::array iterators
+        CC_CONTRACT(bool(_curr));
         CC_CONTRACT(is_valid());
         return *_curr;
     }


### PR DESCRIPTION
- Reactivated the contract in `iterator_cursor`
- Fixed the deduction guide for cc::array
    Previously, `cc::array foo = {1, 2, 3};` would result in a `cc::array<int>` (heap-allocated)
