### PR TITLE
Kw/develop

### DIFF
--- a/src/clean-core/array.hh
+++ b/src/clean-core/array.hh
@@ -4,6 +4,7 @@
 
 #include <clean-core/algorithms.hh>
 #include <clean-core/assert.hh>
+#include <clean-core/detail/container_impl_util.hh>
 #include <clean-core/forward.hh>
 #include <clean-core/fwd.hh>
 #include <clean-core/span.hh>
@@ -79,21 +80,21 @@ struct array<T, dynamic_size>
     {
         _size = data.size();
         _data = new T[_size];
-        cc::copy(data, *this);
+        detail::container_copy_range<T>(data.begin(), _size, _data);
     }
 
     array(span<T> data)
     {
         _size = data.size();
         _data = new T[_size];
-        cc::copy(data, *this);
+        detail::container_copy_range<T>(data.data(), _size, _data);
     }
 
     array(array const& a)
     {
         _size = a._size;
         _data = new T[a._size];
-        cc::copy(a, *this);
+        detail::container_copy_range<T>(a.data(), _size, _data);
     }
     array(array&& a) noexcept
     {
@@ -109,7 +110,7 @@ struct array<T, dynamic_size>
             delete[] _data;
             _size = a._size;
             _data = new T[a._size];
-            cc::copy(a, *this);
+            detail::container_copy_range<T>(a.data(), _size, _data);
         }
         return *this;
     }
@@ -154,7 +155,7 @@ private:
 
 // deduction guides
 template <class T, class... U>
-array(T, U...) -> array<T, 1 + sizeof...(U)>;
+array(T, U...)->array<T, 1 + sizeof...(U)>;
 
 template <class T, class... Args>
 [[nodiscard]] array<T, 1 + sizeof...(Args)> make_array(T&& v0, Args&&... rest)

--- a/src/clean-core/detail/container_impl_util.hh
+++ b/src/clean-core/detail/container_impl_util.hh
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+#include <type_traits>
+
+#include <clean-core/move.hh>
+#include <clean-core/new.hh>
+
+namespace cc::detail
+{
+template <class T, class SizeT = std::size_t>
+void container_move_range(T* src, SizeT num, T* dest)
+{
+    if constexpr (std::is_trivially_move_constructible_v<T> && std::is_trivially_copyable_v<T>)
+    {
+        if (num > 0)
+            std::memcpy(dest, src, sizeof(T) * num);
+    }
+    else
+    {
+        for (SizeT i = 0; i < num; ++i)
+            new (placement_new, &dest[i]) T(cc::move(src[i]));
+    }
+}
+
+template <class T, class SizeT = std::size_t>
+void container_copy_range(T const* src, SizeT num, T* dest)
+{
+    if constexpr (std::is_trivially_copyable_v<T>)
+    {
+        if (num > 0)
+            std::memcpy(dest, src, sizeof(T) * num);
+    }
+    else
+    {
+        for (SizeT i = 0; i < num; ++i)
+            new (placement_new, &dest[i]) T(src[i]);
+    }
+}
+
+template <class T, class SizeT = std::size_t>
+void container_destroy_reverse(T* data, SizeT size, SizeT to_index = 0)
+{
+    if constexpr (!std::is_trivially_destructible_v<T>)
+    {
+        for (SizeT i = size; i > to_index; --i)
+            data[i - 1].~T();
+    }
+}
+}

--- a/src/clean-core/vector.hh
+++ b/src/clean-core/vector.hh
@@ -6,6 +6,7 @@
 #include <type_traits>
 
 #include <clean-core/assert.hh>
+#include <clean-core/detail/container_impl_util.hh>
 #include <clean-core/forward.hh>
 #include <clean-core/fwd.hh>
 #include <clean-core/move.hh>
@@ -70,14 +71,14 @@ public:
     vector(std::initializer_list<T> l)
     {
         reserve(l.size());
-        _copy_range(l.begin(), l.size(), _data);
+        detail::container_copy_range<T>(l.begin(), l.size(), _data);
         _size = l.size();
     }
 
     vector(vector const& rhs)
     {
         reserve(rhs._size);
-        _copy_range(rhs._data, rhs._size, _data);
+        detail::container_copy_range<T>(rhs._data, rhs._size, _data);
         _size = rhs._size;
     }
     vector(vector&& rhs) noexcept
@@ -91,14 +92,14 @@ public:
     }
     ~vector()
     {
-        _destroy_reverse(_data, _size);
+        detail::container_destroy_reverse<T>(_data, _size);
         _free(_data);
     }
     vector& operator=(vector const& rhs)
     {
         if (this != &rhs)
         {
-            _destroy_reverse(_data, _size);
+            detail::container_destroy_reverse<T>(_data, _size);
             // ensure enough memory has been allocated
             if (_capacity < rhs._size)
             {
@@ -106,14 +107,14 @@ public:
                 _data = _alloc(rhs._size);
                 _capacity = rhs._size;
             }
-            _copy_range(rhs._data, rhs._size, _data);
+            detail::container_copy_range<T>(rhs._data, rhs._size, _data);
             _size = rhs._size;
         }
         return *this;
     }
     vector& operator=(vector&& rhs) noexcept
     {
-        _destroy_reverse(_data, _size);
+        detail::container_destroy_reverse<T>(_data, _size);
         _free(_data);
         _data = rhs._data;
         _size = rhs._size;
@@ -162,8 +163,8 @@ public:
         if (size <= _capacity)
             return;
         T* new_data = _alloc(size);
-        _move_range(_data, _size, new_data);
-        _destroy_reverse(_data, _size);
+        detail::container_move_range<T>(_data, _size, new_data);
+        detail::container_destroy_reverse<T>(_data, _size);
         _free(_data);
         _data = new_data;
         _capacity = size;
@@ -193,7 +194,7 @@ public:
 
     void clear()
     {
-        _destroy_reverse(_data, _size);
+        detail::container_destroy_reverse<T>(_data, _size);
         _size = 0;
     }
 
@@ -202,7 +203,7 @@ public:
         if (_size != _capacity)
         {
             T* new_data = _alloc(_size);
-            _move_range(_data, _size, new_data);
+            detail::container_move_range<T>(_data, _size, new_data);
             _free(_data);
             _data = new_data;
             _capacity = _size;
@@ -233,41 +234,6 @@ public:
 private:
     static T* _alloc(size_t size) { return reinterpret_cast<T*>(new std::byte[size * sizeof(T)]); }
     static void _free(T* p) { delete[] reinterpret_cast<std::byte*>(p); }
-
-    static void _move_range(T* src, size_t num, T* dest)
-    {
-        if constexpr (std::is_trivially_move_constructible_v<T> && std::is_trivially_copyable_v<T>)
-        {
-            if (num > 0)
-                std::memcpy(dest, src, sizeof(T) * num);
-        }
-        else
-        {
-            for (size_t i = 0; i < num; ++i)
-                new (placement_new, &dest[i]) T(cc::move(src[i]));
-        }
-    }
-    static void _copy_range(T const* src, size_t num, T* dest)
-    {
-        if constexpr (std::is_trivially_copyable_v<T>)
-        {
-            if (num > 0)
-                std::memcpy(dest, src, sizeof(T) * num);
-        }
-        else
-        {
-            for (size_t i = 0; i < num; ++i)
-                new (placement_new, &dest[i]) T(src[i]);
-        }
-    }
-    static void _destroy_reverse(T* data, size_t size, size_t to_index = 0)
-    {
-        if constexpr (!std::is_trivially_destructible_v<T>)
-        {
-            for (size_t i = size; i > to_index; --i)
-                data[i - 1].~T();
-        }
-    }
 
     void _grow() { reserve(_capacity == 0 ? 1 : _capacity << 1); }
 


### PR DESCRIPTION
- Fix missing rhs invalidation in `capped_array` move ctor
- Fix memcpy UB in `capped_array`
- Add missing contracts to `capped_array` static create methods
- Add triviality optimizations based on move constructibility
- Add missing triviality optimizations to `capped_array` and `capped_vector`