### PR TITLE
Kw/develop

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -54,3 +54,6 @@ AccessModifierOffset: -4
 FixNamespaceComments: false
 AlignTrailingComments: true
 CommentPragmas: '!Api.*'
+
+# Includes
+IncludeBlocks: Preserve

--- a/src/clean-core/capped_vector.hh
+++ b/src/clean-core/capped_vector.hh
@@ -108,7 +108,7 @@ public:
     capped_vector(T const* begin, size_t num_elements)
     {
         CC_CONTRACT(num_elements <= N);
-        _size = num_elements;
+        _size = static_cast<compact_size_t>(num_elements);
         detail::container_copy_range<T>(begin, num_elements, &_u.value[0]);
     }
     capped_vector(std::initializer_list<T> data) : capped_vector(data.begin(), data.size()) {}

--- a/src/clean-core/capped_vector.hh
+++ b/src/clean-core/capped_vector.hh
@@ -10,6 +10,7 @@
 #include <clean-core/forward.hh>
 #include <clean-core/move.hh>
 #include <clean-core/new.hh>
+#include <clean-core/span.hh>
 #include <clean-core/storage.hh>
 
 namespace cc
@@ -104,12 +105,14 @@ public:
         detail::container_move_range<T, compact_size_t>(&rhs._u.value[0], _size, &_u.value[0]);
         rhs._size = 0;
     }
-    capped_vector(std::initializer_list<T> data)
+    capped_vector(T const* begin, size_t num_elements)
     {
-        CC_CONTRACT(data.size() <= N);
-        _size = data.size();
-        detail::container_copy_range<T>(data.begin(), _size, &_u.value[0]);
+        CC_CONTRACT(num_elements <= N);
+        _size = num_elements;
+        detail::container_copy_range<T>(begin, num_elements, &_u.value[0]);
     }
+    capped_vector(std::initializer_list<T> data) : capped_vector(data.begin(), data.size()) {}
+    capped_vector(cc::span<T const> data) : capped_vector(data.begin(), data.size()) {}
 
     capped_vector& operator=(capped_vector const& rhs)
     {
@@ -214,29 +217,23 @@ public:
         _size = compact_size_t(new_size);
     }
 
-    template <size_t M>
-    constexpr bool operator==(capped_vector<T, M> const& rhs) const noexcept
+    bool operator==(cc::span<T const> rhs) const noexcept
     {
-        if (_size != rhs._size)
+        if (_size != rhs.size())
             return false;
         for (size_t i = 0; i < _size; ++i)
-        {
-            if ((*this)[i] != rhs[i])
+            if (!((*this)[i] == rhs[i]))
                 return false;
-        }
         return true;
     }
 
-    template <size_t M>
-    constexpr bool operator!=(capped_vector<T, M> const& rhs) const noexcept
+    bool operator!=(cc::span<T const> rhs) const noexcept
     {
-        if (_size != rhs._size)
+        if (_size != rhs.size())
             return true;
         for (size_t i = 0; i < _size; ++i)
-        {
             if ((*this)[i] != rhs[i])
                 return true;
-        }
         return false;
     }
 

--- a/src/clean-core/native/win32_sanitized.hh
+++ b/src/clean-core/native/win32_sanitized.hh
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <clean-core/macros.hh>
-#ifdef CC_OS_WINDOWS
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32)
 
 // Check if <Windows.h> was included somewhere before this header
 #if defined(_WINDOWS_) && !defined(CC_SANITIZED_WINDOWS_H)
-#pragma message("Including unsanitized Windows.h")
+#pragma message("[clean-core][native/win32_sanitized.hh] Detected unsanitized Windows.h")
 #endif
 #define CC_SANITIZED_WINDOWS_H
 

--- a/src/clean-core/vector.hh
+++ b/src/clean-core/vector.hh
@@ -11,6 +11,7 @@
 #include <clean-core/fwd.hh>
 #include <clean-core/move.hh>
 #include <clean-core/new.hh>
+#include <clean-core/span.hh>
 
 namespace cc
 {
@@ -72,19 +73,16 @@ public:
         return v;
     }
 
-    vector(std::initializer_list<T> l)
+    vector(T const* begin, size_t num_elements)
     {
-        reserve(l.size());
-        detail::container_copy_range<T>(l.begin(), l.size(), _data);
-        _size = l.size();
+        reserve(num_elements);
+        detail::container_copy_range<T>(begin, num_elements, _data);
+        _size = num_elements;
     }
+    vector(std::initializer_list<T> data) : vector(data.begin(), data.size()) {}
+    vector(cc::span<T const> data) : vector(data.begin(), data.size()) {}
+    vector(vector const& rhs) : vector(rhs.begin(), rhs.size()) {}
 
-    vector(vector const& rhs)
-    {
-        reserve(rhs._size);
-        detail::container_copy_range<T>(rhs._data, rhs._size, _data);
-        _size = rhs._size;
-    }
     vector(vector&& rhs) noexcept
     {
         _data = rhs._data;
@@ -212,22 +210,22 @@ public:
         }
     }
 
-    bool operator==(vector const& rhs) const noexcept
+    bool operator==(cc::span<T const> rhs) const noexcept
     {
-        if (_size != rhs._size)
+        if (_size != rhs.size())
             return false;
         for (size_t i = 0; i < _size; ++i)
-            if (_data[i] != rhs._data[i])
+            if (!(_data[i] == rhs[i]))
                 return false;
         return true;
     }
 
-    bool operator!=(vector const& rhs) const noexcept
+    bool operator!=(cc::span<T const> rhs) const noexcept
     {
-        if (_size != rhs._size)
+        if (_size != rhs.size())
             return true;
         for (size_t i = 0; i < _size; ++i)
-            if (_data[i] != rhs._data[i])
+            if (_data[i] != rhs[i])
                 return true;
         return false;
     }


### PR DESCRIPTION
- ctors and `operator==` from `cc::span` for `cc::vector` and `cc::capped_vector`
- [capped_]vector's `operator==` now strictly requires `operator==` from `T` (instead of `operator!=`)
- fixed clang-format file for newer binaries
- improved win32_sanitized warning