### PR TITLE
Added format implementation

### DIFF
--- a/src/clean-core/format.cc
+++ b/src/clean-core/format.cc
@@ -1,0 +1,114 @@
+#include "format.hh"
+
+void cc::vformat_to(string_stream& ss, string_view fmt_str, span<arg_info> args)
+{
+    auto const is_digit = [](unsigned char c) -> bool { return '0' <= c && c <= '9'; };
+    auto const is_letter = [](unsigned char c) -> bool { return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z'); };
+
+    // todo: benchmark if useful
+    ss.reserve(fmt_str.size());
+
+    // if not explicityly given, take the next argument.
+    // Cannot be used after a named or numbered arg was encountered
+    int arg_id = 0;
+
+    // each iteration handle one argument (if there are any)
+    auto char_iter = fmt_str.begin();
+    while (char_iter != fmt_str.end())
+    {
+        auto segment_start = char_iter;
+        // find next occurence of '{', or end, and all occurrences of }}
+        while (*char_iter != '{' && char_iter != fmt_str.end())
+        {
+            if (*char_iter == '}')
+            {
+                ss << string_view(segment_start, char_iter);
+                ++char_iter;
+                CC_ASSERT(*char_iter == '}' && char_iter != fmt_str.end() && "Invalid format string: Unmatched }");
+                segment_start = char_iter;
+            }
+            ++char_iter;
+        }
+
+        // append current segment
+        if (char_iter != segment_start)
+            ss << string_view(segment_start, char_iter);
+
+        // nothing to replace
+        if (char_iter == fmt_str.end())
+            return;
+
+        // else it now points to {
+        ++char_iter;
+        CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
+        if (*char_iter == '{') // escape
+            ss << string_view(char_iter, char_iter + 1);
+        else if (*char_iter == '}')
+        {
+            // case {}
+            CC_ASSERT(arg_id >= 0 && "Cannot use {} after named or indexed argument");
+            args[arg_id].do_format(ss, args[arg_id].data, {});
+            ++arg_id;
+        }
+        else
+        {
+            // either number or named argument or parse args
+            size_t argument_index = -1;
+            if (is_digit(*char_iter)) // number
+            {
+                // todo: are leading zeros valid?
+                size_t index = *char_iter - '0';
+                ++char_iter;
+                while (is_digit(*char_iter))
+                {
+                    index *= 10;
+                    index += *char_iter - '0';
+                    ++char_iter;
+                }
+                CC_ASSERT(index < args.size() && "Invalid format string: index too large");
+                argument_index = index;
+                arg_id = -1; // invalidate
+            }
+            else if (*char_iter == '_' || is_letter(*char_iter)) // named
+            {
+                auto const name_start = char_iter;
+                ++char_iter;
+                while (*char_iter == '_' || is_letter(*char_iter) || is_digit(*char_iter))
+                {
+                    ++char_iter;
+                    CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: index too large");
+                }
+                auto const name = string_view(name_start, char_iter);
+                for (auto i = 0; i < args.size(); ++i)
+                {
+                    if (args[i].name != nullptr && string_view(args[i].name) == name)
+                    {
+                        argument_index = i;
+                        break;
+                    }
+                }
+                arg_id = -1; // invalidate
+                CC_ASSERT(argument_index < args.size() && "Invalid format string: argument name not found");
+            }
+
+            if (*char_iter == '}')
+            {
+                // parse arg
+                args[argument_index].do_format(ss, args[argument_index].data, {});
+            }
+            else
+            {
+                CC_ASSERT(*char_iter == ':' && "Invalid format string: Missing closing }");
+                ++char_iter;
+                auto args_start = char_iter;
+                while (*char_iter != '}' && char_iter != fmt_str.end())
+                    ++char_iter;
+                CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
+                // todo: this is double parsing!
+                // todo: handle arguments that themselves contain args!
+                args[argument_index].do_format(ss, args[argument_index].data, string_view(args_start, char_iter));
+            }
+        }
+        ++char_iter;
+    }
+}

--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -34,7 +34,6 @@ struct default_formatter
 struct arg_info
 {
     function_ptr<void(string_stream&, void const*, string_view)> do_format;
-    function_ptr<bool(string_view)> verify_format_str;
     void const* data = nullptr;
     char const* name = nullptr;
 };
@@ -54,10 +53,6 @@ arg_info make_arg_info(T const& v)
                 // todo take correct version
                 ss << to_string(*static_cast<T const*>(data));
             },
-            [](string_view options) -> bool {
-                // todo: not always the case
-                return options.empty();
-            },
             &v};
 }
 
@@ -69,11 +64,6 @@ arg_info make_arg_info(int const& v)
                 // todo take correct version
                 ss << std::to_string(*static_cast<int const*>(data));
             },
-            [](string_view options) -> bool {
-                // todo: not always the case
-                return options.empty();
-                // todo: special formatting
-            },
             &v};
 }
 
@@ -83,10 +73,6 @@ arg_info make_arg_info(arg<T> const& a)
     return {[](string_stream& ss, void const* data, string_view options) -> void {
                 // todo take correct version
                 ss << to_string(*static_cast<T const*>(data));
-            },
-            [](string_view options) -> bool {
-                // todo: not always the case
-                return options.empty();
             },
             &a.value, a.name};
 }
@@ -194,7 +180,6 @@ void vformat_to(string_stream& s, string_view fmt_str, span<arg_info> args)
                     ++it;
                 CC_ASSERT(it != fmt_str.end() && "Invalid format string: Missing closing }");
                 // todo: this is double parsing!
-                CC_ASSERT(args[argument_index].verify_format_str(string_view(args_start, it)) && "Invalid format arguments");
                 args[argument_index].do_format(s, args[argument_index].data, string_view(args_start, it));
             }
         }

--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -1,0 +1,233 @@
+#pragma once
+
+#include <string> // temporary
+
+#include <clean-core/function_ptr.hh>
+#include <clean-core/span.hh>
+#include <clean-core/string.hh>
+#include <clean-core/string_stream.hh>
+#include <clean-core/string_view.hh>
+
+/*
+ * TODO:
+ * * No arguments currently not possible
+ * * allow formatter customization
+ */
+
+namespace cc
+{
+struct default_formatter
+{
+    template <class T>
+    void to_string(string_stream& ss, T const& v, string_view fmt_args)
+    {
+        // todo:
+        // Select one of
+        // cc::string to_string(T const&);
+        // cc::string to_string(T const&, cc::string_view fmt_args);
+        // void to_string(cc::string_stream&, T const&);
+        // void to_string(cc::string_stream&, T const&, cc::string_view fmt_args);
+    }
+};
+
+
+struct arg_info
+{
+    function_ptr<void(string_stream&, void const*, string_view)> do_format;
+    function_ptr<bool(string_view)> verify_format_str;
+    void const* data = nullptr;
+    char const* name = nullptr;
+};
+
+template <class T>
+struct arg
+{
+    arg(char const* name, T const& v) : name{name}, value{v} {}
+    char const* name = nullptr;
+    T const& value = {};
+};
+
+template <class T>
+arg_info make_arg_info(T const& v)
+{
+    return {[](string_stream& ss, void const* data, string_view options) -> void {
+                // todo take correct version
+                ss << to_string(*static_cast<T const*>(data));
+            },
+            [](string_view options) -> bool {
+                // todo: not always the case
+                return options.empty();
+            },
+            &v};
+}
+
+// todo: all builtin types
+
+arg_info make_arg_info(int const& v)
+{
+    return {[](string_stream& ss, void const* data, string_view options) -> void {
+                // todo take correct version
+                ss << std::to_string(*static_cast<int const*>(data));
+            },
+            [](string_view options) -> bool {
+                // todo: not always the case
+                return options.empty();
+                // todo: special formatting
+            },
+            &v};
+}
+
+template <class T>
+arg_info make_arg_info(arg<T> const& a)
+{
+    return {[](string_stream& ss, void const* data, string_view options) -> void {
+                // todo take correct version
+                ss << to_string(*static_cast<T const*>(data));
+            },
+            [](string_view options) -> bool {
+                // todo: not always the case
+                return options.empty();
+            },
+            &a.value, a.name};
+}
+
+
+void vformat_to(string_stream& s, string_view fmt_str, span<arg_info> args)
+{
+    auto const is_digit = [](unsigned char c) -> bool { return '0' <= c && c <= '9'; };
+    auto const is_letter = [](unsigned char c) -> bool { return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z'); };
+
+    // todo: benchmark if useful
+    s.reserve(fmt_str.size());
+
+    // if not explicityly given, take the next argument
+    // todo: what happens when named / numbered args are used before {}
+    int arg_id = 0;
+
+    // each iteration handle one argument (if there are any)
+    auto it = fmt_str.begin();
+    while (it != fmt_str.end())
+    {
+        auto segment_start = it;
+        // find next occurence of '{', or end, and all occurrences of }}
+        while (*it != '{' && it != fmt_str.end())
+        {
+            if (*it == '}')
+            {
+                s << string_view(segment_start, it);
+                ++it;
+                CC_ASSERT(*it == '}' && it != fmt_str.end() && "Invalid format string: Unmatched }");
+                segment_start = it;
+            }
+            ++it;
+        }
+
+        // append current segment
+        if (it != segment_start)
+            s << string_view(segment_start, it);
+
+        // nothing to replace
+        if (it == fmt_str.end())
+            return;
+
+        // else it now points to {
+        ++it;
+        CC_ASSERT(it != fmt_str.end() && "Invalid format string: Missing closing }");
+        if (*it == '{') // escape
+            s << string_view(it, it + 1);
+        else if (*it == '}')
+        {
+            // case {}
+            args[arg_id].do_format(s, args[arg_id].data, {});
+            ++arg_id;
+        }
+        else
+        {
+            // either number or named argument or parse args
+            size_t argument_index = -1;
+            if (is_digit(*it)) // number
+            {
+                // todo: are leading zeros valid?
+                size_t index = *it - '0';
+                ++it;
+                while (is_digit(*it))
+                {
+                    index *= 10;
+                    index += *it - '0';
+                    ++it;
+                }
+                CC_ASSERT(index < args.size() && "Invalid format string: index too large");
+                argument_index = index;
+            }
+            else if (*it == '_' || is_letter(*it)) // named
+            {
+                auto const name_start = it;
+                ++it;
+                while (*it == '_' || is_letter(*it) || is_digit(*it))
+                {
+                    ++it;
+                    CC_ASSERT(it != fmt_str.end() && "Invalid format string: index too large");
+                }
+                auto const name = string_view(name_start, it);
+                for (auto i = 0; i < args.size(); ++i)
+                {
+                    if (args[i].name != nullptr && string_view(args[i].name) == name)
+                    {
+                        argument_index = i;
+                        break;
+                    }
+                }
+                CC_ASSERT(argument_index < args.size() && "Invalid format string: argument name not found");
+            }
+
+            if (*it == '}')
+            {
+                // parse arg
+                args[argument_index].do_format(s, args[argument_index].data, {});
+            }
+            else
+            {
+                CC_ASSERT(*it == ':' && "Invalid format string: Missing closing }");
+                ++it;
+                auto args_start = it;
+                while (*it != '}' && it != fmt_str.end())
+                    ++it;
+                CC_ASSERT(it != fmt_str.end() && "Invalid format string: Missing closing }");
+                // todo: this is double parsing!
+                CC_ASSERT(args[argument_index].verify_format_str(string_view(args_start, it)) && "Invalid format arguments");
+                args[argument_index].do_format(s, args[argument_index].data, string_view(args_start, it));
+            }
+        }
+        ++it;
+    }
+}
+
+string vformat(string_view fmt_str, span<arg_info> args)
+{
+    string_stream ss;
+    vformat_to(ss, fmt_str, args);
+    return ss.to_string();
+}
+
+template <class Formatter = default_formatter, class... Args>
+void format_to(string_stream& ss, string_view fmt_str, Args const&... args)
+{
+    arg_info vargs[] = {make_arg_info(args)...};
+    vformat_to(ss, fmt_str, vargs);
+}
+
+template <class Formatter = default_formatter, class... Args>
+string format(char const* fmt_str, Args const&... args)
+{
+    arg_info vargs[] = {make_arg_info(args)...};
+    return vformat(fmt_str, vargs);
+}
+
+/* Do we want this?
+template <class Formatter = default_formatter, class... Args>
+void print(FILE* out, char const* fmt_str, Args const&... args)
+{
+    // todo
+}
+*/
+}

--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <string> // temporary
 #include <type_traits>
 
 #include <clean-core/function_ptr.hh>
 #include <clean-core/span.hh>
-#include <clean-core/string.hh>
 #include <clean-core/string_stream.hh>
 #include <clean-core/string_view.hh>
+#include <clean-core/typedefs.hh>
 
 namespace cc
 {
@@ -69,52 +68,6 @@ template <class T>
 constexpr bool has_member_to_string = has_member_to_string_t<T>::value;
 }
 
-// to_string implementations for builtin types
-// format_spec ::=  [[fill]align][sign]["#"]["0"][width]["." precision][type]
-// fill        ::=  <a character other than '{' or '}'>
-// align       ::=  "<" | ">" | "^"
-// sign        ::=  "+" | "-" | " "
-// width       ::=  integer | "{" arg_id "}"
-// precision   ::=  integer | "{" arg_id "}"
-// type        ::=  int_type | "a" | "A" | "c" | "e" | "E" | "f" | "F" | "g" | "G" | "L" | "p" | "s"
-// int_type    ::=  "b" | "B" | "d" | "o" | "x" | "X"
-
-template <class T>
-void to_string(string_stream& ss, T const* b, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, bool b, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, string const& s, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, char c, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, int v, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, float v, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, double v, string_view fmt_args)
-{
-    // todo parse
-}
-
 struct default_formatter
 {
     template <class T>
@@ -152,7 +105,7 @@ struct default_formatter
         }
         else
         {
-            static_assert(false, "Type requires a to_string() method");
+            static_assert(cc::always_false<T>, "Type requires a to_string() method");
         }
     }
 };
@@ -221,12 +174,4 @@ string format(char const* fmt_str, Args const&... args)
         return vformat(fmt_str, vargs);
     }
 }
-
-/* Do we want this?
-template <class Formatter = default_formatter, class... Args>
-void print(FILE* out, char const* fmt_str, Args const&... args)
-{
-    // todo
-}
-*/
 }


### PR DESCRIPTION
This is a base version of a fmtlib (or python)-like format. 
This implementation moves a lot of the heavy lifting to the user by providing to_string methods that accept fmt_string options and handles formatting themselves.

It is planned to add to_string versions that handle format strings the same way (or close to) fmtlib does.