### PR TITLE
Add native/wchar_conversion.hh

### DIFF
--- a/src/clean-core/native/wchar_conversion.cc
+++ b/src/clean-core/native/wchar_conversion.cc
@@ -7,16 +7,14 @@
 
 #include <clean-core/native/win32_sanitized.hh>
 
-static_assert(sizeof(char) == 1 && sizeof(wchar_t) == 2, "Unsupported environment");
-
 int cc::widechar_to_char(char* dest, int max_num_dest_chars, const wchar_t* src, int opt_num_src_chars)
 {
 #ifdef CC_OS_WINDOWS
     return ::WideCharToMultiByte(CP_UTF8, 0, src, opt_num_src_chars, dest, max_num_dest_chars, nullptr, nullptr);
 #else
     std::mbstate_t state = {};
-    unsigned num_dest_chars = opt_num_src_chars > 0 ? cc::min(max_num_dest_chars, opt_num_src_chars / 2) : max_num_dest_chars;
-    return std::wcsrtombs(dest, &src, num_dest_chars, &state);
+    int num_dest_chars = opt_num_src_chars > 0 ? cc::min(max_num_dest_chars, opt_num_src_chars / int(sizeof(wchar_t))) : max_num_dest_chars;
+    return int(std::wcsrtombs(dest, &src, size_t(num_dest_chars), &state));
 #endif
 }
 
@@ -26,7 +24,7 @@ int cc::char_to_widechar(wchar_t* dest, int max_num_dest_chars, const char* src,
     return ::MultiByteToWideChar(CP_UTF8, 0, src, opt_num_src_chars, dest, max_num_dest_chars);
 #else
     std::mbstate_t state = {};
-    unsigned num_dest_chars = opt_num_src_chars > 0 ? cc::min(max_num_dest_chars, opt_num_src_chars) : max_num_dest_chars;
-    return std::mbsrtowcs(dest, &src, num_dest_chars, &state);
+    int num_dest_chars = opt_num_src_chars > 0 ? cc::min(max_num_dest_chars, opt_num_src_chars) : max_num_dest_chars;
+    return int(std::mbsrtowcs(dest, &src, size_t(num_dest_chars), &state));
 #endif
 }

--- a/src/clean-core/native/wchar_conversion.cc
+++ b/src/clean-core/native/wchar_conversion.cc
@@ -7,24 +7,24 @@
 
 #include <clean-core/native/win32_sanitized.hh>
 
-int cc::widechar_to_char(char* dest, int max_num_dest_chars, const wchar_t* src, int opt_num_src_chars)
+int cc::widechar_to_char(cc::span<char> dest, const wchar_t* src, int opt_num_src_chars)
 {
 #ifdef CC_OS_WINDOWS
-    return ::WideCharToMultiByte(CP_UTF8, 0, src, opt_num_src_chars, dest, max_num_dest_chars, nullptr, nullptr);
+    return ::WideCharToMultiByte(CP_UTF8, 0, src, opt_num_src_chars, dest.data(), int(dest.size()), nullptr, nullptr);
 #else
     std::mbstate_t state = {};
-    int num_dest_chars = opt_num_src_chars > 0 ? cc::min(max_num_dest_chars, opt_num_src_chars / int(sizeof(wchar_t))) : max_num_dest_chars;
-    return int(std::wcsrtombs(dest, &src, size_t(num_dest_chars), &state));
+    int num_dest_chars = opt_num_src_chars > 0 ? cc::min(int(dest.size()), opt_num_src_chars / int(sizeof(wchar_t))) : int(dest.size());
+    return int(std::wcsrtombs(dest.data(), &src, size_t(num_dest_chars), &state));
 #endif
 }
 
-int cc::char_to_widechar(wchar_t* dest, int max_num_dest_chars, const char* src, int opt_num_src_chars)
+int cc::char_to_widechar(cc::span<wchar_t> dest, const char* src, int opt_num_src_chars)
 {
 #ifdef CC_OS_WINDOWS
-    return ::MultiByteToWideChar(CP_UTF8, 0, src, opt_num_src_chars, dest, max_num_dest_chars);
+    return ::MultiByteToWideChar(CP_UTF8, 0, src, opt_num_src_chars, dest.data(), int(dest.size()));
 #else
     std::mbstate_t state = {};
-    int num_dest_chars = opt_num_src_chars > 0 ? cc::min(max_num_dest_chars, opt_num_src_chars) : max_num_dest_chars;
-    return int(std::mbsrtowcs(dest, &src, size_t(num_dest_chars), &state));
+    int num_dest_chars = opt_num_src_chars > 0 ? cc::min(int(dest.size()), opt_num_src_chars) : int(dest.size());
+    return int(std::mbsrtowcs(dest.data(), &src, size_t(num_dest_chars), &state));
 #endif
 }

--- a/src/clean-core/native/wchar_conversion.cc
+++ b/src/clean-core/native/wchar_conversion.cc
@@ -1,0 +1,32 @@
+#include "wchar_conversion.hh"
+
+#include <cwchar>
+
+#include <clean-core/macros.hh>
+#include <clean-core/utility.hh>
+
+#include <clean-core/native/win32_sanitized.hh>
+
+static_assert(sizeof(char) == 1 && sizeof(wchar_t) == 2, "Unsupported environment");
+
+int cc::widechar_to_char(char* dest, int max_num_dest_chars, const wchar_t* src, int opt_num_src_chars)
+{
+#ifdef CC_OS_WINDOWS
+    return ::WideCharToMultiByte(CP_UTF8, 0, src, opt_num_src_chars, dest, max_num_dest_chars, nullptr, nullptr);
+#else
+    std::mbstate_t state = {};
+    unsigned num_dest_chars = opt_num_src_chars > 0 ? cc::min(max_num_dest_chars, opt_num_src_chars / 2) : max_num_dest_chars;
+    return std::wcsrtombs(dest, &src, num_dest_chars, &state);
+#endif
+}
+
+int cc::char_to_widechar(wchar_t* dest, int max_num_dest_chars, const char* src, int opt_num_src_chars)
+{
+#ifdef CC_OS_WINDOWS
+    return ::MultiByteToWideChar(CP_UTF8, 0, src, opt_num_src_chars, dest, max_num_dest_chars);
+#else
+    std::mbstate_t state = {};
+    unsigned num_dest_chars = opt_num_src_chars > 0 ? cc::min(max_num_dest_chars, opt_num_src_chars) : max_num_dest_chars;
+    return std::mbsrtowcs(dest, &src, num_dest_chars, &state);
+#endif
+}

--- a/src/clean-core/native/wchar_conversion.hh
+++ b/src/clean-core/native/wchar_conversion.hh
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace cc
+{
+/// converts a wchar_t string to a (UTF-8) char string
+/// opt_num_src_chars can be specified to stop conversion before '\0' terminateion
+/// returns amount of characters written to dest
+int widechar_to_char(char* dest, int max_num_dest_chars, wchar_t const* src, int opt_num_src_chars = -1);
+
+/// converts a (UTF-8) char string to a wchar_t string
+/// opt_num_src_chars can be specified to stop conversion before '\0' terminateion
+/// returns amount of characters written to dest
+int char_to_widechar(wchar_t* dest, int max_num_dest_chars, char const* src, int opt_num_src_chars = -1);
+}

--- a/src/clean-core/native/wchar_conversion.hh
+++ b/src/clean-core/native/wchar_conversion.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <clean-core/span.hh>
+
 namespace cc
 {
 /// converts a wchar_t string to a (UTF-8) char string
@@ -7,8 +9,18 @@ namespace cc
 /// returns amount of characters written to dest
 int widechar_to_char(char* dest, int max_num_dest_chars, wchar_t const* src, int opt_num_src_chars = -1);
 
+inline int widechar_to_char(cc::span<char> dest, wchar_t const* src, int opt_num_src_chars = -1)
+{
+    return widechar_to_char(dest.data(), int(dest.size()), src, opt_num_src_chars);
+}
+
 /// converts a (UTF-8) char string to a wchar_t string
 /// opt_num_src_chars can be specified to stop conversion before '\0' terminateion
 /// returns amount of characters written to dest
 int char_to_widechar(wchar_t* dest, int max_num_dest_chars, char const* src, int opt_num_src_chars = -1);
+
+inline int char_to_widechar(cc::span<wchar_t> dest, char const* src, int opt_num_src_chars = -1)
+{
+    return char_to_widechar(dest.data(), int(dest.size()), src, opt_num_src_chars);
+}
 }

--- a/src/clean-core/native/wchar_conversion.hh
+++ b/src/clean-core/native/wchar_conversion.hh
@@ -7,20 +7,10 @@ namespace cc
 /// converts a wchar_t string to a (UTF-8) char string
 /// opt_num_src_chars can be specified to stop conversion before '\0' terminateion
 /// returns amount of characters written to dest
-int widechar_to_char(char* dest, int max_num_dest_chars, wchar_t const* src, int opt_num_src_chars = -1);
-
-inline int widechar_to_char(cc::span<char> dest, wchar_t const* src, int opt_num_src_chars = -1)
-{
-    return widechar_to_char(dest.data(), int(dest.size()), src, opt_num_src_chars);
-}
+int widechar_to_char(cc::span<char> dest, wchar_t const* src, int opt_num_src_chars = -1);
 
 /// converts a (UTF-8) char string to a wchar_t string
 /// opt_num_src_chars can be specified to stop conversion before '\0' terminateion
 /// returns amount of characters written to dest
-int char_to_widechar(wchar_t* dest, int max_num_dest_chars, char const* src, int opt_num_src_chars = -1);
-
-inline int char_to_widechar(cc::span<wchar_t> dest, char const* src, int opt_num_src_chars = -1)
-{
-    return char_to_widechar(dest.data(), int(dest.size()), src, opt_num_src_chars);
-}
+int char_to_widechar(cc::span<wchar_t> dest, char const* src, int opt_num_src_chars = -1);
 }


### PR DESCRIPTION
Thin wrapper for (mostly Win32) `wchar` to `char` conversion and vice versa, simple interface and no warnings. Also runs on Linux using `<cwchar>` functions.