### PR TITLE
Feature/string stream append char

### DIFF
--- a/src/clean-core/format.cc
+++ b/src/clean-core/format.cc
@@ -1,0 +1,114 @@
+#include "format.hh"
+
+void cc::vformat_to(string_stream& ss, string_view fmt_str, span<arg_info> args)
+{
+    auto const is_digit = [](unsigned char c) -> bool { return '0' <= c && c <= '9'; };
+    auto const is_letter = [](unsigned char c) -> bool { return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z'); };
+
+    // todo: benchmark if useful
+    ss.reserve(fmt_str.size());
+
+    // if not explicityly given, take the next argument.
+    // Cannot be used after a named or numbered arg was encountered
+    int arg_id = 0;
+
+    // each iteration handle one argument (if there are any)
+    auto char_iter = fmt_str.begin();
+    while (char_iter != fmt_str.end())
+    {
+        auto segment_start = char_iter;
+        // find next occurence of '{', or end, and all occurrences of }}
+        while (*char_iter != '{' && char_iter != fmt_str.end())
+        {
+            if (*char_iter == '}')
+            {
+                ss << string_view(segment_start, char_iter);
+                ++char_iter;
+                CC_ASSERT(*char_iter == '}' && char_iter != fmt_str.end() && "Invalid format string: Unmatched }");
+                segment_start = char_iter;
+            }
+            ++char_iter;
+        }
+
+        // append current segment
+        if (char_iter != segment_start)
+            ss << string_view(segment_start, char_iter);
+
+        // nothing to replace
+        if (char_iter == fmt_str.end())
+            return;
+
+        // else it now points to {
+        ++char_iter;
+        CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
+        if (*char_iter == '{') // escape
+            ss << string_view(char_iter, char_iter + 1);
+        else if (*char_iter == '}')
+        {
+            // case {}
+            CC_ASSERT(arg_id >= 0 && "Cannot use {} after named or indexed argument");
+            args[arg_id].do_format(ss, args[arg_id].data, {});
+            ++arg_id;
+        }
+        else
+        {
+            // either number or named argument or parse args
+            size_t argument_index = -1;
+            if (is_digit(*char_iter)) // number
+            {
+                // todo: are leading zeros valid?
+                size_t index = *char_iter - '0';
+                ++char_iter;
+                while (is_digit(*char_iter))
+                {
+                    index *= 10;
+                    index += *char_iter - '0';
+                    ++char_iter;
+                }
+                CC_ASSERT(index < args.size() && "Invalid format string: index too large");
+                argument_index = index;
+                arg_id = -1; // invalidate
+            }
+            else if (*char_iter == '_' || is_letter(*char_iter)) // named
+            {
+                auto const name_start = char_iter;
+                ++char_iter;
+                while (*char_iter == '_' || is_letter(*char_iter) || is_digit(*char_iter))
+                {
+                    ++char_iter;
+                    CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: index too large");
+                }
+                auto const name = string_view(name_start, char_iter);
+                for (auto i = 0; i < args.size(); ++i)
+                {
+                    if (args[i].name != nullptr && string_view(args[i].name) == name)
+                    {
+                        argument_index = i;
+                        break;
+                    }
+                }
+                arg_id = -1; // invalidate
+                CC_ASSERT(argument_index < args.size() && "Invalid format string: argument name not found");
+            }
+
+            if (*char_iter == '}')
+            {
+                // parse arg
+                args[argument_index].do_format(ss, args[argument_index].data, {});
+            }
+            else
+            {
+                CC_ASSERT(*char_iter == ':' && "Invalid format string: Missing closing }");
+                ++char_iter;
+                auto args_start = char_iter;
+                while (*char_iter != '}' && char_iter != fmt_str.end())
+                    ++char_iter;
+                CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
+                // todo: this is double parsing!
+                // todo: handle arguments that themselves contain args!
+                args[argument_index].do_format(ss, args[argument_index].data, string_view(args_start, char_iter));
+            }
+        }
+        ++char_iter;
+    }
+}

--- a/src/clean-core/format.cc
+++ b/src/clean-core/format.cc
@@ -16,13 +16,13 @@ void cc::detail::vformat_to(cc::string_stream& ss, cc::string_view fmt_str, cc::
     {
         auto segment_start = char_iter;
         // find next occurence of '{', or end, and all occurrences of "}}"
-        while (*char_iter != '{' && char_iter != fmt_str.end())
+        while (char_iter != fmt_str.end() && *char_iter != '{')
         {
             if (*char_iter == '}')
             {
                 ss << cc::string_view(segment_start, char_iter);
                 ++char_iter;
-                CC_ASSERT(*char_iter == '}' && char_iter != fmt_str.end() && "Invalid format string: Unmatched }");
+                CC_ASSERT(char_iter != fmt_str.end() && *char_iter == '}' && "Invalid format string: Unmatched }");
                 segment_start = char_iter;
             }
             ++char_iter;
@@ -57,11 +57,13 @@ void cc::detail::vformat_to(cc::string_stream& ss, cc::string_view fmt_str, cc::
                 // todo: are leading zeros valid?
                 size_t index = *char_iter - '0';
                 ++char_iter;
+                CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
                 while (is_digit(*char_iter))
                 {
                     index *= 10;
                     index += *char_iter - '0';
                     ++char_iter;
+                    CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
                 }
                 CC_ASSERT(index < args.size() && "Invalid format string: Argument index too large");
                 argument_index = index;
@@ -71,10 +73,11 @@ void cc::detail::vformat_to(cc::string_stream& ss, cc::string_view fmt_str, cc::
             {
                 auto const name_start = char_iter;
                 ++char_iter;
+                CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
                 while (*char_iter == '_' || is_lower(*char_iter) || is_upper(*char_iter) || is_digit(*char_iter))
                 {
                     ++char_iter;
-                    CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Argument index too large");
+                    CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
                 }
                 auto const name = cc::string_view(name_start, char_iter);
                 for (auto i = 0; i < args.size(); ++i)
@@ -88,6 +91,7 @@ void cc::detail::vformat_to(cc::string_stream& ss, cc::string_view fmt_str, cc::
                 arg_id = -1; // invalidate
                 CC_ASSERT(argument_index < args.size() && "Invalid format string: Argument name not found");
             }
+            CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
             if (*char_iter == '}')
             {
                 // we can only reach this if either a named or indexed argument is parsed
@@ -97,10 +101,13 @@ void cc::detail::vformat_to(cc::string_stream& ss, cc::string_view fmt_str, cc::
             {
                 CC_ASSERT(*char_iter == ':' && "Invalid format string: Missing closing }");
                 ++char_iter;
-                auto const args_start = char_iter;
-                while (char_iter != fmt_str.end() && *char_iter != '}')
-                    ++char_iter;
                 CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
+                auto const args_start = char_iter;
+                while (*char_iter != '}')
+                {
+                    ++char_iter;
+                    CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
+                }
                 // todo: handle arguments that themselves contain args
                 args[argument_index].do_format(ss, args[argument_index].data, cc::string_view(args_start, char_iter));
             }

--- a/src/clean-core/format.cc
+++ b/src/clean-core/format.cc
@@ -80,9 +80,9 @@ void cc::detail::vformat_to(cc::string_stream& ss, cc::string_view fmt_str, cc::
                     CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
                 }
                 auto const name = cc::string_view(name_start, char_iter);
-                for (auto i = 0; i < args.size(); ++i)
+                for (auto i = 0u; i < args.size(); ++i)
                 {
-                    if (args[i].name != nullptr && cc::string_view(args[i].name) == name)
+                    if (!args[i].name.empty() && args[i].name == name)
                     {
                         argument_index = i;
                         break;

--- a/src/clean-core/format.cc
+++ b/src/clean-core/format.cc
@@ -91,6 +91,10 @@ void cc::detail::vformat_to(cc::string_stream& ss, cc::string_view fmt_str, cc::
                 arg_id = -1; // invalidate
                 CC_ASSERT(argument_index < args.size() && "Invalid format string: Argument name not found");
             }
+            else
+            {
+                argument_index = arg_id++;
+            }
             CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
             if (*char_iter == '}')
             {

--- a/src/clean-core/format.cc
+++ b/src/clean-core/format.cc
@@ -2,7 +2,7 @@
 
 #include <clean-core/char_predicates.hh>
 
-void cc::detail::vformat_to(cc::string_stream& ss, cc::string_view fmt_str, cc::span<arg_info> args)
+void cc::detail::vformat_to(cc::string_stream& ss, cc::string_view fmt_str, cc::span<arg_info const> args)
 {
     ss.reserve(fmt_str.size());
 

--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -34,7 +34,6 @@ struct default_formatter
 struct arg_info
 {
     function_ptr<void(string_stream&, void const*, string_view)> do_format;
-    function_ptr<bool(string_view)> verify_format_str;
     void const* data = nullptr;
     char const* name = nullptr;
 };
@@ -54,10 +53,6 @@ arg_info make_arg_info(T const& v)
                 // todo take correct version
                 ss << to_string(*static_cast<T const*>(data));
             },
-            [](string_view options) -> bool {
-                // todo: not always the case
-                return options.empty();
-            },
             &v};
 }
 
@@ -69,11 +64,6 @@ arg_info make_arg_info(int const& v)
                 // todo take correct version
                 ss << std::to_string(*static_cast<int const*>(data));
             },
-            [](string_view options) -> bool {
-                // todo: not always the case
-                return options.empty();
-                // todo: special formatting
-            },
             &v};
 }
 
@@ -83,10 +73,6 @@ arg_info make_arg_info(arg<T> const& a)
     return {[](string_stream& ss, void const* data, string_view options) -> void {
                 // todo take correct version
                 ss << to_string(*static_cast<T const*>(data));
-            },
-            [](string_view options) -> bool {
-                // todo: not always the case
-                return options.empty();
             },
             &a.value, a.name};
 }
@@ -194,7 +180,6 @@ void vformat_to(string_stream& s, string_view fmt_str, span<arg_info> args)
                     ++it;
                 CC_ASSERT(it != fmt_str.end() && "Invalid format string: Missing closing }");
                 // todo: this is double parsing!
-                CC_ASSERT(args[argument_index].verify_format_str(string_view(args_start, it)) && "Invalid format arguments");
                 args[argument_index].do_format(s, args[argument_index].data, string_view(args_start, it));
             }
         }

--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -1,0 +1,233 @@
+#pragma once
+
+#include <string> // temporary
+
+#include <clean-core/function_ptr.hh>
+#include <clean-core/span.hh>
+#include <clean-core/string.hh>
+#include <clean-core/string_stream.hh>
+#include <clean-core/string_view.hh>
+
+/*
+ * TODO:
+ * * No arguments currently not possible
+ * * allow formatter customization
+ */
+
+namespace cc
+{
+struct default_formatter
+{
+    template <class T>
+    void to_string(string_stream& ss, T const& v, string_view fmt_args)
+    {
+        // todo:
+        // Select one of
+        // cc::string to_string(T const&);
+        // cc::string to_string(T const&, cc::string_view fmt_args);
+        // void to_string(cc::string_stream&, T const&);
+        // void to_string(cc::string_stream&, T const&, cc::string_view fmt_args);
+    }
+};
+
+
+struct arg_info
+{
+    function_ptr<void(string_stream&, void const*, string_view)> do_format;
+    function_ptr<bool(string_view)> verify_format_str;
+    void const* data = nullptr;
+    char const* name = nullptr;
+};
+
+template <class T>
+struct arg
+{
+    arg(char const* name, T const& v) : name{name}, value{v} {}
+    char const* name = nullptr;
+    T const& value = {};
+};
+
+template <class T>
+arg_info make_arg_info(T const& v)
+{
+    return {[](string_stream& ss, void const* data, string_view options) -> void {
+                // todo take correct version
+                ss << to_string(*static_cast<T const*>(data));
+            },
+            [](string_view options) -> bool {
+                // todo: not always the case
+                return options.empty();
+            },
+            &v};
+}
+
+// todo: all builtin types
+
+arg_info make_arg_info(int const& v)
+{
+    return {[](string_stream& ss, void const* data, string_view options) -> void {
+                // todo take correct version
+                ss << std::to_string(*static_cast<int const*>(data));
+            },
+            [](string_view options) -> bool {
+                // todo: not always the case
+                return options.empty();
+                // todo: special formatting
+            },
+            &v};
+}
+
+template <class T>
+arg_info make_arg_info(arg<T> const& a)
+{
+    return {[](string_stream& ss, void const* data, string_view options) -> void {
+                // todo take correct version
+                ss << to_string(*static_cast<T const*>(data));
+            },
+            [](string_view options) -> bool {
+                // todo: not always the case
+                return options.empty();
+            },
+            &a.value, a.name};
+}
+
+
+void vformat_to(string_stream& s, string_view fmt_str, span<arg_info> args)
+{
+    auto const is_digit = [](unsigned char c) -> bool { return '0' <= c && c <= '9'; };
+    auto const is_letter = [](unsigned char c) -> bool { return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z'); };
+
+    // todo: benchmark if useful
+    s.reserve(fmt_str.size());
+
+    // if not explicityly given, take the next argument
+    // todo: what happens when named / numbered args are used before {}
+    int arg_id = 0;
+
+    // each iteration handle one argument (if there are any)
+    auto it = fmt_str.begin();
+    while (it != fmt_str.end())
+    {
+        auto segment_start = it;
+        // find next occurence of '{', or end, and all occurrences of }}
+        while (*it != '{' && it != fmt_str.end())
+        {
+            if (*it == '}')
+            {
+                s << string_view(segment_start, it);
+                ++it;
+                CC_ASSERT(*it == '}' && it != fmt_str.end() && "Invalid format string: Unmatched }");
+                segment_start = it;
+            }
+            ++it;
+        }
+
+        // append current segment
+        if (it != segment_start)
+            s << string_view(segment_start, it);
+
+        // nothing to replace
+        if (it == fmt_str.end())
+            return;
+
+        // else it now points to {
+        ++it;
+        CC_ASSERT(it != fmt_str.end() && "Invalid format string: Missing closing }");
+        if (*it == '{') // escape
+            s << string_view(it, it + 1);
+        else if (*it == '}')
+        {
+            // case {}
+            args[arg_id].do_format(s, args[arg_id].data, {});
+            ++arg_id;
+        }
+        else
+        {
+            // either number or named argument or parse args
+            size_t argument_index = -1;
+            if (is_digit(*it)) // number
+            {
+                // todo: are leading zeros valid?
+                size_t index = *it - '0';
+                ++it;
+                while (is_digit(*it))
+                {
+                    index *= 10;
+                    index += *it - '0';
+                    ++it;
+                }
+                CC_ASSERT(index < args.size() && "Invalid format string: index too large");
+                argument_index = index;
+            }
+            else if (*it == '_' || is_letter(*it)) // named
+            {
+                auto const name_start = it;
+                ++it;
+                while (*it == '_' || is_letter(*it) || is_digit(*it))
+                {
+                    ++it;
+                    CC_ASSERT(it != fmt_str.end() && "Invalid format string: index too large");
+                }
+                auto const name = string_view(name_start, it);
+                for (auto i = 0; i < args.size(); ++i)
+                {
+                    if (args[i].name != nullptr && string_view(args[i].name) == name)
+                    {
+                        argument_index = i;
+                        break;
+                    }
+                }
+                CC_ASSERT(argument_index < args.size() && "Invalid format string: argument name not found");
+            }
+
+            if (*it == '}')
+            {
+                // parse arg
+                args[argument_index].do_format(s, args[argument_index].data, {});
+            }
+            else
+            {
+                CC_ASSERT(*it == ':' && "Invalid format string: Missing closing }");
+                ++it;
+                auto args_start = it;
+                while (*it != '}' && it != fmt_str.end())
+                    ++it;
+                CC_ASSERT(it != fmt_str.end() && "Invalid format string: Missing closing }");
+                // todo: this is double parsing!
+                CC_ASSERT(args[argument_index].verify_format_str(string_view(args_start, it)) && "Invalid format arguments");
+                args[argument_index].do_format(s, args[argument_index].data, string_view(args_start, it));
+            }
+        }
+        ++it;
+    }
+}
+
+string vformat(string_view fmt_str, span<arg_info> args)
+{
+    string_stream ss;
+    vformat_to(ss, fmt_str, args);
+    return ss.to_string();
+}
+
+template <class Formatter = default_formatter, class... Args>
+void format_to(string_stream& ss, string_view fmt_str, Args const&... args)
+{
+    arg_info vargs[] = {make_arg_info(args)...};
+    vformat_to(ss, fmt_str, vargs);
+}
+
+template <class Formatter = default_formatter, class... Args>
+string format(char const* fmt_str, Args const&... args)
+{
+    arg_info vargs[] = {make_arg_info(args)...};
+    return vformat(fmt_str, vargs);
+}
+
+/* Do we want this?
+template <class Formatter = default_formatter, class... Args>
+void print(FILE* out, char const* fmt_str, Args const&... args)
+{
+    // todo
+}
+*/
+}

--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -132,7 +132,7 @@ arg_info make_arg_info(format_arg<T> const& a)
             &a.value, a.name};
 }
 
-void vformat_to(string_stream& ss, string_view fmt_str, span<arg_info> args);
+void vformat_to(string_stream& ss, string_view fmt_str, span<arg_info const> args);
 }
 
 template <class T>

--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <string> // temporary
 #include <type_traits>
 
 #include <clean-core/function_ptr.hh>
 #include <clean-core/span.hh>
-#include <clean-core/string.hh>
 #include <clean-core/string_stream.hh>
 #include <clean-core/string_view.hh>
+#include <clean-core/typedefs.hh>
 
 namespace cc
 {
@@ -69,52 +68,6 @@ template <class T>
 constexpr bool has_member_to_string = has_member_to_string_t<T>::value;
 }
 
-// to_string implementations for builtin types
-// format_spec ::=  [[fill]align][sign]["#"]["0"][width]["." precision][type]
-// fill        ::=  <a character other than '{' or '}'>
-// align       ::=  "<" | ">" | "^"
-// sign        ::=  "+" | "-" | " "
-// width       ::=  integer | "{" arg_id "}"
-// precision   ::=  integer | "{" arg_id "}"
-// type        ::=  int_type | "a" | "A" | "c" | "e" | "E" | "f" | "F" | "g" | "G" | "L" | "p" | "s"
-// int_type    ::=  "b" | "B" | "d" | "o" | "x" | "X"
-
-template <class T>
-void to_string(string_stream& ss, T const* b, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, bool b, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, string const& s, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, char c, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, int v, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, float v, string_view fmt_args)
-{
-    // todo parse
-}
-
-void to_string(string_stream& ss, double v, string_view fmt_args)
-{
-    // todo parse
-}
-
 struct default_formatter
 {
     template <class T>
@@ -152,7 +105,7 @@ struct default_formatter
         }
         else
         {
-            static_assert(false, "Type requires a to_string() method");
+            static_assert(cc::always_false<T>, "Type requires a to_string() method");
         }
     }
 };
@@ -221,12 +174,4 @@ string format(char const* fmt_str, Args const&... args)
         return vformat(fmt_str, vargs);
     }
 }
-
-/* Do we want this?
-template <class Formatter = default_formatter, class... Args>
-void print(FILE* out, char const* fmt_str, Args const&... args)
-{
-    // todo
-}
-*/
 }

--- a/src/clean-core/string_stream.hh
+++ b/src/clean-core/string_stream.hh
@@ -18,6 +18,14 @@ public: // methods
         return *this;
     }
 
+    string_stream& operator<<(char c)
+    {
+        reserve(1);
+        *m_curr = c;
+        ++m_curr;
+        return *this;
+    }
+
     [[nodiscard]] string to_string() const
     {
         if (empty())

--- a/src/clean-core/to_string.cc
+++ b/src/clean-core/to_string.cc
@@ -753,38 +753,18 @@ void to_string_float_impl(cc::string_stream& ss, FloatType value, parsed_fmt_arg
         to_string(sprintf_args, args.precision, "");
     }
 
-    switch (args.type)
+    if (args.type == 0)
+    { // note: currently same as g due to limitation of sprintf
+        sprintf_args << "g";
+    }
+    else
     {
-    case 0: // default, like g but always one digit after decimal point, when fixed point notation is used
-            // note: currently same as g due to limitation of sprintf
-        sprintf_args << "g";
-        break;
-    case 'a': // hexadecimal 0x prefix, 'p' exponent, lowercase letters
-        sprintf_args << "a";
-        break;
-    case 'A': // hexadecimal 0x prefix, 'P' exponent, uppercase letters
-        sprintf_args << "A";
-        break;
-    case 'e': // scientific exponent notation, 'e' exponent
-        sprintf_args << "e";
-        break;
-    case 'E': // scientific exponent notation, 'E' exponent
-        sprintf_args << "E";
-        break;
-    case 'f': // fixed-point
-        sprintf_args << "f";
-        break;
-    case 'F': // fixed-point, but "nan" and "inf" become "NAN" and "INF"
-        sprintf_args << "F";
-        break;
-    case 'g': // general form, precision significant digits and fixed-point or exponent notation depending on magnitute
-        sprintf_args << "g";
-        break;
-    case 'G': // same as 'g' but uppercase version
-        sprintf_args << "G";
-        break;
-    default:
-        CC_ASSERT(cc::always_false<FloatType> && "Invalid format string: Unsupported argument type for float type");
+        CC_ASSERT((args.type == 'a' || args.type == 'A' || //
+                   args.type == 'e' || args.type == 'E' || //
+                   args.type == 'f' || args.type == 'F' || //
+                   args.type == 'g' || args.type == 'G')
+                  && "Invalid format string: Unsupported argument type for float type");
+        sprintf_args << cc::string_view(&args.type, 1);
     }
 
     // Note: We cannot explicitly convert float as long as we do not run our own float conversion, because sprintf will automatically convert float to double

--- a/src/clean-core/to_string.cc
+++ b/src/clean-core/to_string.cc
@@ -8,6 +8,12 @@
 #include <clean-core/assert.hh>
 #include <clean-core/char_predicates.hh>
 
+cc::string cc::to_string(char value) { return string::filled(1, value); }
+cc::string cc::to_string(bool value) { return value ? "true" : "false"; }
+cc::string cc::to_string(const char* value) { return value == nullptr ? "[nullptr]" : value; }
+cc::string cc::to_string(cc::string_view value) { return value; }
+cc::string cc::to_string(cc::nullptr_t) { return "nullptr"; }
+
 cc::string cc::to_string(void* value)
 {
     if (value == nullptr)

--- a/src/clean-core/to_string.cc
+++ b/src/clean-core/to_string.cc
@@ -7,6 +7,9 @@
 #include <clean-core/always_false.hh>
 #include <clean-core/assert.hh>
 #include <clean-core/char_predicates.hh>
+#include <clean-core/string.hh>
+#include <clean-core/string_stream.hh>
+#include <clean-core/string_view.hh>
 
 cc::string cc::to_string(char value) { return string::filled(1, value); }
 cc::string cc::to_string(bool value) { return value ? "true" : "false"; }
@@ -138,6 +141,156 @@ cc::string cc::to_string(std::byte value)
     s[1] = hex[v / 16];
     return s;
 }
+
+cc::string to_string(char value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(bool value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(char const* value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(cc::string_view value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(nullptr_t, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, nullptr_t{}, fmt_str);
+    return ss.to_string();
+}
+
+cc::string to_string(void* value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+
+cc::string to_string(std::byte value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+
+cc::string to_string(signed char value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(short value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(int value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(long value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(long long value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(unsigned char value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(unsigned short value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(unsigned int value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(unsigned long value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(unsigned long long value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+
+cc::string to_string(float value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(double value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+cc::string to_string(long double value, cc::string_view fmt_str)
+{
+    cc::string_stream ss;
+    to_string(ss, value, fmt_str);
+    return ss.to_string();
+}
+
+void to_string(cc::string_stream& ss, char value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, bool value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, char const* value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, cc::string_view value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, nullptr_t) { to_string(ss, nullptr_t{}, ""); }
+
+void to_string(cc::string_stream& ss, void* value) { to_string(ss, value, ""); }
+
+void to_string(cc::string_stream& ss, std::byte value) { to_string(ss, value, ""); }
+
+void to_string(cc::string_stream& ss, signed char value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, short value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, int value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, long value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, long long value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, unsigned char value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, unsigned short value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, unsigned int value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, unsigned long value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, unsigned long long value) { to_string(ss, value, ""); }
+
+void to_string(cc::string_stream& ss, float value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, double value) { to_string(ss, value, ""); }
+void to_string(cc::string_stream& ss, long double value) { to_string(ss, value, ""); }
 
 namespace
 {

--- a/src/clean-core/to_string.cc
+++ b/src/clean-core/to_string.cc
@@ -95,3 +95,267 @@ cc::string cc::to_string(std::byte value)
     s[1] = hex[v / 16];
     return s;
 }
+
+
+// to_string implementations for builtin types
+// format_spec ::=  [[fill]align][sign]["#"]["0"][width]["." precision][type]
+// fill        ::=  <a character other than '{' or '}'>
+// align       ::=  "<" | ">" | "^"
+// sign        ::=  "+" | "-" | " "
+// width       ::=  integer | "{" arg_id "}"
+// precision   ::=  integer | "{" arg_id "}"
+// type        ::=  int_type | "a" | "A" | "c" | "e" | "E" | "f" | "F" | "g" | "G" | "L" | "p" | "s"
+// int_type    ::=  "b" | "B" | "d" | "o" | "x" | "X"
+namespace
+{
+struct int_fmt_args
+{
+    char fill = 0;                        // anything but '{' or '}', only valid if align valid
+    char align = 0;                       // '<': left | '>': right | '^': center
+    char sign = '-';                      // '+': show both + and - | '-': show only - | ' ': show only -, but leave space if +
+    bool alternative_mode = false;        // alternative display mode
+    bool sign_aware_zero_padding = false; // add leading zeros after the sign +0000123
+    int width = -1;                       //
+    char type = 'd';                      // types 'b': binary | 'B': Binary | 'd': decimal | 'o': octal | 'x':hex | 'X': heX [ | L: locale aware]
+};
+
+
+// todo: generic parse int
+void parse_int_args(int v, cc::string_view fmt_args)
+{
+    auto const is_align = [](char c) { return c == '<' || c == '>' || c == '^'; };
+    auto const is_sign = [](char c) { return c == '+' || c == '-' || c == ' '; };
+    auto const is_digit = [](char c) { return '0' <= c && c <= '9'; };
+
+    auto it = fmt_args.begin();
+    auto const end = fmt_args.end();
+
+    char fill;
+    char const* align = nullptr; // != nullptr if aligned
+    char sign = '-';             // default
+    bool alternative = false;
+    bool sign_aware_zero_padding = false;
+    int width = -1;
+    char type = 'd';
+
+    // fill and alignment
+    if (fmt_args.size() >= 2 && is_align(*(it + 1)))
+    {
+        fill = *it;
+        ++it;
+        align = it;
+        ++it;
+    }
+    // sign
+    if (it != end && is_sign(*it))
+    {
+        sign = *it;
+        ++it;
+    }
+    // alternative mode
+    if (it != end && (*it == '#'))
+    {
+        alternative = true;
+        ++it;
+    }
+    // zero padding and width
+    if (it != end && (*it == '0'))
+    {
+        sign_aware_zero_padding = true;
+        ++it;
+        CC_ASSERT(it != end && is_digit(*it) && "Invalid format string: zero padding must be followed by by width");
+        CC_ASSERT(*it != '0' && "Invalid format string: width can have at most one preceeding zero");
+        width = *it - '0';
+        ++it;
+        while (it != end && is_digit(*it))
+        {
+            width *= 10;
+            width += *it - '0';
+            ++it;
+        }
+    }
+    // no zero padding and with
+    if (it != end && is_digit(*it))
+    {
+        width = *it - '0';
+        ++it;
+        while (it != end && is_digit(*it))
+        {
+            width *= 10;
+            width += *it - '0';
+            ++it;
+        }
+    }
+    // precision does not apply to integer and is therefore skipped
+    // integer types
+    if (it != end)
+    {
+        // todo: locale?
+        CC_ASSERT((*it == 'b' || *it == 'B' || *it == 'd' || *it == 'o' || *it == 'x' || *it == 'X') && "Invalid format string: unsupported type");
+        type = *it;
+        ++it;
+    }
+    CC_ASSERT(it == end && "Invalid format string: invalid integer options");
+
+    // todo: what do with settings?
+}
+
+void parse_float(float, cc::string_view fmt_args)
+{
+    auto const is_align = [](char c) { return c == '<' || c == '>' || c == '^'; };
+    auto const is_sign = [](char c) { return c == '+' || c == '-' || c == ' '; };
+    auto const is_digit = [](char c) { return '0' <= c && c <= '9'; };
+
+    auto it = fmt_args.begin();
+    auto const end = fmt_args.end();
+
+    char fill;
+    char const* align = nullptr; // != nullptr if aligned
+    char sign = '-';             // default
+    bool alternative = false;
+    bool sign_aware_zero_padding = false;
+    int width = -1;
+    char type = 'd';
+    int precision = -1;
+
+    // fill and alignment
+    if (fmt_args.size() >= 2 && is_align(*(it + 1)))
+    {
+        fill = *it;
+        ++it;
+        align = it;
+        ++it;
+    }
+    // sign
+    if (it != end && is_sign(*it))
+    {
+        sign = *it;
+        ++it;
+    }
+    // alternative mode
+    if (it != end && (*it == '#'))
+    {
+        alternative = true;
+        ++it;
+    }
+    // zero padding and width
+    if (it != end && (*it == '0'))
+    {
+        sign_aware_zero_padding = true;
+        ++it;
+        CC_ASSERT(it != end && is_digit(*it) && "Invalid format string: zero padding must be followed by by width");
+        CC_ASSERT(*it != '0' && "Invalid format string: width can have at most one preceeding zero");
+        width = *it - '0';
+        ++it;
+        while (it != end && is_digit(*it))
+        {
+            width *= 10;
+            width += *it - '0';
+            ++it;
+        }
+    }
+    // no zero padding and with
+    if (it != end && is_digit(*it))
+    {
+        width = *it - '0';
+        ++it;
+        while (it != end && is_digit(*it))
+        {
+            width *= 10;
+            width += *it - '0';
+            ++it;
+        }
+    }
+    if (it != end && *it == '.')
+    {
+        ++it;
+        CC_ASSERT(it != end && is_digit(*it) && "Invalid format string: . must be followed by the precision");
+        precision = *it - '0';
+        ++it;
+        while (it != end && is_digit(*it))
+        {
+            precision *= 10;
+            precision += *it - '0';
+            ++it;
+        }
+    }
+
+    // type
+    if (it != end) // todo: locale?
+    {
+        CC_ASSERT((*it == 'a' || *it == 'A' || *it == 'e' || *it == 'E' || *it == 'f' || *it == 'F' || *it == 'g' || *it == 'G') && "Invalid format string: invalid type");
+        type = *it;
+        ++it;
+    }
+    CC_ASSERT(it == end && "Invalid format string: invalid integer options");
+}
+}
+
+// void cc::to_string(cc::string_stream& ss, char value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+// void cc::to_string(cc::string_stream& ss, bool value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+// void cc::to_string(cc::string_stream& ss, char const* value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+// void cc::to_string(cc::string_stream& ss, cc::string_view value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+// void cc::to_string(cc::string_stream& ss, nullptr_t, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+
+// void cc::to_string(cc::string_stream& ss, void* value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+
+// void cc::to_string(cc::string_stream& ss, std::byte value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+
+// void cc::to_string(cc::string_stream& ss, int value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+// void cc::to_string(cc::string_stream& ss, long value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+// void cc::to_string(cc::string_stream& ss, long long value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+// void cc::to_string(cc::string_stream& ss, unsigned int value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+// void cc::to_string(cc::string_stream& ss, unsigned long value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+// void cc::to_string(cc::string_stream& ss, unsigned long long value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+
+// void cc::to_string(cc::string_stream& ss, float value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+// void cc::to_string(cc::string_stream& ss, double value, cc::string_view fmt_str)
+//{
+//    // todo
+//}
+// void cc::to_string(cc::string_stream& ss, long double value, cc::string_view fmt_str)
+//{
+//    // todo
+//}

--- a/src/clean-core/to_string.hh
+++ b/src/clean-core/to_string.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <clean-core/string.hh>
+#include <clean-core/string_stream.hh>
 
 namespace cc
 {
@@ -24,4 +25,26 @@ string to_string(unsigned long long value);
 string to_string(float value);
 string to_string(double value);
 string to_string(long double value);
+
+// void to_string(string_stream& ss, char value, string_view fmt_str);
+// void to_string(string_stream& ss, bool value, string_view fmt_str);
+// void to_string(string_stream& ss, char const* value, string_view fmt_str);
+// void to_string(string_stream& ss, string_view value, string_view fmt_str);
+// void to_string(string_stream& ss, nullptr_t, string_view fmt_str);
+
+// void to_string(string_stream& ss, void* value, string_view fmt_str);
+
+// void to_string(string_stream& ss, std::byte value, string_view fmt_str);
+
+// void to_string(string_stream& ss, int value, string_view fmt_str);
+// void to_string(string_stream& ss, long value, string_view fmt_str);
+// void to_string(string_stream& ss, long long value, string_view fmt_str);
+// void to_string(string_stream& ss, unsigned int value, string_view fmt_str);
+// void to_string(string_stream& ss, unsigned long value, string_view fmt_str);
+// void to_string(string_stream& ss, unsigned long long value, string_view fmt_str);
+
+// void to_string(string_stream& ss, float value, string_view fmt_str);
+// void to_string(string_stream& ss, double value, string_view fmt_str);
+// void to_string(string_stream& ss, long double value, string_view fmt_str);
+
 }

--- a/src/clean-core/to_string.hh
+++ b/src/clean-core/to_string.hh
@@ -29,6 +29,56 @@ string to_string(float value);
 string to_string(double value);
 string to_string(long double value);
 
+string to_string(char value, string_view fmt_str);
+string to_string(bool value, string_view fmt_str);
+string to_string(char const* value, string_view fmt_str);
+string to_string(string_view value, string_view fmt_str);
+string to_string(nullptr_t, string_view fmt_str);
+
+string to_string(void* value, string_view fmt_str);
+
+string to_string(std::byte value, string_view fmt_str);
+
+string to_string(signed char value, string_view fmt_str);
+string to_string(short value, string_view fmt_str);
+string to_string(int value, string_view fmt_str);
+string to_string(long value, string_view fmt_str);
+string to_string(long long value, string_view fmt_str);
+string to_string(unsigned char value, string_view fmt_str);
+string to_string(unsigned short value, string_view fmt_str);
+string to_string(unsigned int value, string_view fmt_str);
+string to_string(unsigned long value, string_view fmt_str);
+string to_string(unsigned long long value, string_view fmt_str);
+
+string to_string(float value, string_view fmt_str);
+string to_string(double value, string_view fmt_str);
+string to_string(long double value, string_view fmt_str);
+
+void to_string(string_stream& ss, char value);
+void to_string(string_stream& ss, bool value);
+void to_string(string_stream& ss, char const* value);
+void to_string(string_stream& ss, string_view value);
+void to_string(string_stream& ss, nullptr_t);
+
+void to_string(string_stream& ss, void* value);
+
+void to_string(string_stream& ss, std::byte value);
+
+void to_string(string_stream& ss, signed char value);
+void to_string(string_stream& ss, short value);
+void to_string(string_stream& ss, int value);
+void to_string(string_stream& ss, long value);
+void to_string(string_stream& ss, long long value);
+void to_string(string_stream& ss, unsigned char value);
+void to_string(string_stream& ss, unsigned short value);
+void to_string(string_stream& ss, unsigned int value);
+void to_string(string_stream& ss, unsigned long value);
+void to_string(string_stream& ss, unsigned long long value);
+
+void to_string(string_stream& ss, float value);
+void to_string(string_stream& ss, double value);
+void to_string(string_stream& ss, long double value);
+
 void to_string(string_stream& ss, char value, string_view fmt_str);
 void to_string(string_stream& ss, bool value, string_view fmt_str);
 void to_string(string_stream& ss, char const* value, string_view fmt_str);

--- a/src/clean-core/to_string.hh
+++ b/src/clean-core/to_string.hh
@@ -15,9 +15,13 @@ string to_string(void* value);
 
 string to_string(std::byte value);
 
+string to_string(signed char value);
+string to_string(short value);
 string to_string(int value);
 string to_string(long value);
 string to_string(long long value);
+string to_string(unsigned char value);
+string to_string(unsigned short value);
 string to_string(unsigned int value);
 string to_string(unsigned long value);
 string to_string(unsigned long long value);
@@ -36,9 +40,13 @@ void to_string(string_stream& ss, void* value, string_view fmt_str);
 
 void to_string(string_stream& ss, std::byte value, string_view fmt_str);
 
+void to_string(string_stream& ss, signed char value, string_view fmt_str);
+void to_string(string_stream& ss, short value, string_view fmt_str);
 void to_string(string_stream& ss, int value, string_view fmt_str);
 void to_string(string_stream& ss, long value, string_view fmt_str);
 void to_string(string_stream& ss, long long value, string_view fmt_str);
+void to_string(string_stream& ss, unsigned char value, string_view fmt_str);
+void to_string(string_stream& ss, unsigned short value, string_view fmt_str);
 void to_string(string_stream& ss, unsigned int value, string_view fmt_str);
 void to_string(string_stream& ss, unsigned long value, string_view fmt_str);
 void to_string(string_stream& ss, unsigned long long value, string_view fmt_str);

--- a/src/clean-core/to_string.hh
+++ b/src/clean-core/to_string.hh
@@ -26,25 +26,24 @@ string to_string(float value);
 string to_string(double value);
 string to_string(long double value);
 
-// void to_string(string_stream& ss, char value, string_view fmt_str);
-// void to_string(string_stream& ss, bool value, string_view fmt_str);
-// void to_string(string_stream& ss, char const* value, string_view fmt_str);
-// void to_string(string_stream& ss, string_view value, string_view fmt_str);
-// void to_string(string_stream& ss, nullptr_t, string_view fmt_str);
+void to_string(string_stream& ss, char value, string_view fmt_str);
+void to_string(string_stream& ss, bool value, string_view fmt_str);
+void to_string(string_stream& ss, char const* value, string_view fmt_str);
+void to_string(string_stream& ss, string_view value, string_view fmt_str);
+void to_string(string_stream& ss, nullptr_t, string_view fmt_str);
 
-// void to_string(string_stream& ss, void* value, string_view fmt_str);
+void to_string(string_stream& ss, void* value, string_view fmt_str);
 
-// void to_string(string_stream& ss, std::byte value, string_view fmt_str);
+void to_string(string_stream& ss, std::byte value, string_view fmt_str);
 
-// void to_string(string_stream& ss, int value, string_view fmt_str);
-// void to_string(string_stream& ss, long value, string_view fmt_str);
-// void to_string(string_stream& ss, long long value, string_view fmt_str);
-// void to_string(string_stream& ss, unsigned int value, string_view fmt_str);
-// void to_string(string_stream& ss, unsigned long value, string_view fmt_str);
-// void to_string(string_stream& ss, unsigned long long value, string_view fmt_str);
+void to_string(string_stream& ss, int value, string_view fmt_str);
+void to_string(string_stream& ss, long value, string_view fmt_str);
+void to_string(string_stream& ss, long long value, string_view fmt_str);
+void to_string(string_stream& ss, unsigned int value, string_view fmt_str);
+void to_string(string_stream& ss, unsigned long value, string_view fmt_str);
+void to_string(string_stream& ss, unsigned long long value, string_view fmt_str);
 
-// void to_string(string_stream& ss, float value, string_view fmt_str);
-// void to_string(string_stream& ss, double value, string_view fmt_str);
-// void to_string(string_stream& ss, long double value, string_view fmt_str);
-
+void to_string(string_stream& ss, float value, string_view fmt_str);
+void to_string(string_stream& ss, double value, string_view fmt_str);
+void to_string(string_stream& ss, long double value, string_view fmt_str);
 }

--- a/src/clean-core/to_string.hh
+++ b/src/clean-core/to_string.hh
@@ -1,15 +1,14 @@
 #pragma once
 
-#include <clean-core/string.hh>
-#include <clean-core/string_stream.hh>
+#include <clean-core/fwd.hh>
 
 namespace cc
 {
-inline string to_string(char value) { return string::filled(1, value); }
-inline string to_string(bool value) { return value ? "true" : "false"; }
-inline string to_string(char const* value) { return value == nullptr ? "[nullptr]" : value; }
-inline string to_string(string_view value) { return value; }
-inline string to_string(nullptr_t) { return "nullptr"; }
+string to_string(char value);
+string to_string(bool value);
+string to_string(char const* value);
+string to_string(string_view value);
+string to_string(nullptr_t);
 
 string to_string(void* value);
 


### PR DESCRIPTION
So far, to append a single `char`, it was necessary to do the following:
```cpp
cc::string_stream ss;
char c = 'c';
ss << cc::string_view(&c, 1);
```
Now it is possible to append a single char.
```cpp
cc::string_stream ss;
ss << 'c';
```
