### PR TITLE
Added string_stream& operator<<(char c)

### DIFF
--- a/src/clean-core/string_stream.hh
+++ b/src/clean-core/string_stream.hh
@@ -18,6 +18,14 @@ public: // methods
         return *this;
     }
 
+    string_stream& operator<<(char c)
+    {
+        reserve(1);
+        *m_curr = c;
+        ++m_curr;
+        return *this;
+    }
+
     [[nodiscard]] string to_string() const
     {
         if (empty())


### PR DESCRIPTION
Added operator to allow writing 
```cpp
cc::string_stream ss;
ss << 'c';
```
instead of 
```cpp
cc::string_stream ss;
char c = 'c';
ss << string_view(&c, 1);
```