### PR TITLE
Pt/develop

### DIFF
--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -149,12 +149,12 @@ void format_to(stream_ref<char> s, string_view fmt_str, Args const&... args)
 {
     if constexpr (sizeof...(args) == 0)
     {
-        vformat_to(s, fmt_str, {});
+        detail::vformat_to(s, fmt_str, {});
     }
     else
     {
         detail::arg_info vargs[] = {detail::make_arg_info(args)...};
-        vformat_to(s, fmt_str, vargs);
+        detail::vformat_to(s, fmt_str, vargs);
     }
 }
 

--- a/src/clean-core/span.hh
+++ b/src/clean-core/span.hh
@@ -123,7 +123,7 @@ auto as_byte_span(T&& value)
         static_assert(std::is_trivially_copyable_v<ElementT>, "cannot convert range of non-trivially copyable elements to byte span");
         return span<byte const>{reinterpret_cast<byte const*>(value.data()), sizeof(ElementT) * value.size()};
     }
-    else if constexpr (std::is_const_v<T>)
+    else if constexpr (std::is_const_v<std::remove_reference_t<T>>)
     {
         // single POD type
         static_assert(std::is_trivially_copyable_v<std::remove_reference_t<T>>, "cannot convert non-trivially copyable element to byte span");

--- a/src/clean-core/span.hh
+++ b/src/clean-core/span.hh
@@ -26,8 +26,11 @@ public:
     constexpr span(T (&data)[N]) : _data(data), _size(N)
     {
     }
+
+    /// generic span constructor from contiguous_range
+    /// CAUTION: container MUST outlive the span!
     template <class Container, cc::enable_if<is_contiguous_range<Container, T>> = true>
-    constexpr span(Container& c) : _data(c.data()), _size(c.size())
+    constexpr span(Container&& c) : _data(c.data()), _size(c.size())
     {
     }
 

--- a/src/clean-core/stream_ref.hh
+++ b/src/clean-core/stream_ref.hh
@@ -30,7 +30,7 @@ struct stream_ref
         _append_fun = [](span<T const>) {};
     }
 
-    /// any function taking a span of Ts can be used to create a stream (generic version)
+    /// any function taking a span of Ts can be used to create a stream
     template <class F, cc::enable_if<std::is_invocable_r_v<void, F, span<T const>>> = true>
     stream_ref(F&& fun)
     {
@@ -58,8 +58,6 @@ private:
     cc::function_ref<void(span<T const>)> _append_fun;
 };
 
-/// special case: adding string_views to a char stream is fine
-inline stream_ref<char>& operator<<(stream_ref<char>& stream, string_view value) { return stream << span<char const>(value.data(), value.size()); }
 /// special case: avoid ambiguous overload by explicitly caring for string literals
 inline stream_ref<char>& operator<<(stream_ref<char>& stream, char const* value) { return stream << string_view(value); }
 

--- a/src/clean-core/to_string.cc
+++ b/src/clean-core/to_string.cc
@@ -167,10 +167,10 @@ cc::string to_string(cc::string_view value, cc::string_view fmt_str)
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(nullptr_t, cc::string_view fmt_str)
+cc::string to_string(std::nullptr_t, cc::string_view fmt_str)
 {
     cc::string s;
-    to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, nullptr_t{}, fmt_str);
+    to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, std::nullptr_t{}, fmt_str);
     return s;
 }
 
@@ -272,7 +272,7 @@ void to_string(cc::stream_ref<char> ss, char value) { to_string(ss, value, ""); 
 void to_string(cc::stream_ref<char> ss, bool value) { to_string(ss, value, ""); }
 void to_string(cc::stream_ref<char> ss, char const* value) { to_string(ss, value, ""); }
 void to_string(cc::stream_ref<char> ss, cc::string_view value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, nullptr_t) { to_string(ss, nullptr_t{}, ""); }
+void to_string(cc::stream_ref<char> ss, std::nullptr_t) { to_string(ss, std::nullptr_t{}, ""); }
 
 void to_string(cc::stream_ref<char> ss, void* value) { to_string(ss, value, ""); }
 
@@ -470,14 +470,15 @@ void unsigned_to_string_impl(cc::stream_ref<char> ss, IntType value, parsed_fmt_
         if constexpr (sizeof(IntType) == 4)
         {
             char buffer[10 + 1 + 1];
-            // the cast prevents a warning on MSVC where 32 bit integer are unsigned long
+            // the cast prevents a warning when unsigned long is 32bit
             auto const length = std::snprintf(buffer, sizeof(buffer), "%u", static_cast<unsigned int>(value));
             ss << cc::string_view(buffer, length);
         }
         if constexpr (sizeof(IntType) == 8)
         {
             char buffer[19 + 1 + 1];
-            auto const length = std::snprintf(buffer, sizeof(buffer), "%llu", value);
+            // the cast prevents a warning when unsigned long is 64bit
+            auto const length = std::snprintf(buffer, sizeof(buffer), "%llu", static_cast<unsigned long long>(value));
             ss << cc::string_view(buffer, length);
         }
     }
@@ -572,14 +573,15 @@ void unsigned_to_string_impl(cc::stream_ref<char> ss, IntType value, parsed_fmt_
         if constexpr (sizeof(IntType) == 4)
         {
             char buffer[10 + 1 + 1];
-            // the cast prevents a warning on MSVC where 32 bit integer are unsigned long
+            // the cast prevents a warning when unsigned long is 32bit
             auto const length = std::snprintf(buffer, sizeof(buffer), "%o", static_cast<unsigned int>(value));
             ss << cc::string_view(buffer, length);
         }
         if constexpr (sizeof(IntType) == 8)
         {
             char buffer[19 + 1 + 1];
-            auto const length = std::snprintf(buffer, sizeof(buffer), "%llo", value);
+            // the cast prevents a warning when unsigned long is 64bit
+            auto const length = std::snprintf(buffer, sizeof(buffer), "%llo", static_cast<unsigned long long>(value));
             ss << cc::string_view(buffer, length);
         }
     }
@@ -603,14 +605,15 @@ void unsigned_to_string_impl(cc::stream_ref<char> ss, IntType value, parsed_fmt_
             if constexpr (sizeof(IntType) == 4)
             {
                 char buffer[10 + 1 + 1];
-                // the cast prevents a warning on MSVC where 32 bit integer are unsigned long
+                // the cast prevents a warning when unsigned long is 32bit
                 auto const length = std::snprintf(buffer, sizeof(buffer), "%#x", static_cast<unsigned int>(value));
                 ss << cc::string_view(buffer, length);
             }
             if constexpr (sizeof(IntType) == 8)
             {
                 char buffer[19 + 1 + 1];
-                auto const length = std::snprintf(buffer, sizeof(buffer), "%#llx", value);
+                // the cast prevents a warning when unsigned long is 64bit
+                auto const length = std::snprintf(buffer, sizeof(buffer), "%#llx", static_cast<unsigned long long>(value));
                 ss << cc::string_view(buffer, length);
             }
         }
@@ -631,14 +634,15 @@ void unsigned_to_string_impl(cc::stream_ref<char> ss, IntType value, parsed_fmt_
             if constexpr (sizeof(IntType) == 4)
             {
                 char buffer[10 + 1 + 1];
-                // the cast prevents a warning on MSVC where 32 bit integer are unsigned long
+                // the cast prevents a warning when unsigned long is 32bit
                 auto const length = std::snprintf(buffer, sizeof(buffer), "%x", static_cast<unsigned int>(value));
                 ss << cc::string_view(buffer, length);
             }
             if constexpr (sizeof(IntType) == 8)
             {
                 char buffer[19 + 1 + 1];
-                auto const length = std::snprintf(buffer, sizeof(buffer), "%llx", value);
+                // the cast prevents a warning when unsigned long is 64bit
+                auto const length = std::snprintf(buffer, sizeof(buffer), "%llx", static_cast<unsigned long long>(value));
                 ss << cc::string_view(buffer, length);
             }
         }
@@ -663,14 +667,15 @@ void unsigned_to_string_impl(cc::stream_ref<char> ss, IntType value, parsed_fmt_
             if constexpr (sizeof(IntType) == 4)
             {
                 char buffer[10 + 1 + 1];
-                // the cast prevents a warning on MSVC where 32 bit integer are unsigned long
+                // the cast prevents a warning when unsigned long is 32bit
                 auto const length = std::snprintf(buffer, sizeof(buffer), "%#X", static_cast<unsigned int>(value));
                 ss << cc::string_view(buffer, length);
             }
             if constexpr (sizeof(IntType) == 8)
             {
                 char buffer[19 + 1 + 1];
-                auto const length = std::snprintf(buffer, sizeof(buffer), "%#llX", value);
+                // the cast prevents a warning when unsigned long is 64bit
+                auto const length = std::snprintf(buffer, sizeof(buffer), "%#llX", static_cast<unsigned long long>(value));
                 ss << cc::string_view(buffer, length);
             }
         }
@@ -691,14 +696,15 @@ void unsigned_to_string_impl(cc::stream_ref<char> ss, IntType value, parsed_fmt_
             if constexpr (sizeof(IntType) == 4)
             {
                 char buffer[10 + 1 + 1];
-                // the cast prevents a warning on MSVC where 32 bit integer are unsigned long
+                // the cast prevents a warning when unsigned long is 32bit
                 auto const length = std::snprintf(buffer, sizeof(buffer), "%X", static_cast<unsigned int>(value));
                 ss << cc::string_view(buffer, length);
             }
             if constexpr (sizeof(IntType) == 8)
             {
                 char buffer[19 + 1 + 1];
-                auto const length = std::snprintf(buffer, sizeof(buffer), "%llX", value);
+                // the cast prevents a warning when unsigned long is 64bit
+                auto const length = std::snprintf(buffer, sizeof(buffer), "%llX", static_cast<unsigned long long>(value));
                 ss << cc::string_view(buffer, length);
             }
         }
@@ -747,11 +753,11 @@ void to_string_float_impl(cc::stream_ref<char> ss, FloatType value, parsed_fmt_a
     if (args.sign_aware_zero_padding)
         sprintf_args << "0";
     if (args.width >= 0)
-        to_string(cc::make_stream_ref<char>(sprintf_args), args.width, "");
+        cc::to_string(cc::make_stream_ref<char>(sprintf_args), args.width, "");
     if (args.precision >= 0)
     {
         sprintf_args << ".";
-        to_string(cc::make_stream_ref<char>(sprintf_args), args.precision, "");
+        cc::to_string(cc::make_stream_ref<char>(sprintf_args), args.precision, "");
     }
 
     if (args.type == 0)
@@ -760,11 +766,7 @@ void to_string_float_impl(cc::stream_ref<char> ss, FloatType value, parsed_fmt_a
     }
     else
     {
-        CC_ASSERT((args.type == 'a' || args.type == 'A' || //
-                   args.type == 'e' || args.type == 'E' || //
-                   args.type == 'f' || args.type == 'F' || //
-                   args.type == 'g' || args.type == 'G')
-                  && "Invalid format string: Unsupported argument type for float type");
+        CC_ASSERT(is_float_type(args.type) && "Invalid format string: Unsupported argument type for float type");
         sprintf_args << cc::string_view(&args.type, 1);
     }
 

--- a/src/clean-core/to_string.hh
+++ b/src/clean-core/to_string.hh
@@ -8,7 +8,7 @@ string to_string(char value);
 string to_string(bool value);
 string to_string(char const* value);
 string to_string(string_view value);
-string to_string(nullptr_t);
+string to_string(std::nullptr_t);
 
 string to_string(void* value);
 
@@ -33,7 +33,7 @@ string to_string(char value, string_view fmt_str);
 string to_string(bool value, string_view fmt_str);
 string to_string(char const* value, string_view fmt_str);
 string to_string(string_view value, string_view fmt_str);
-string to_string(nullptr_t, string_view fmt_str);
+string to_string(std::nullptr_t, string_view fmt_str);
 
 string to_string(void* value, string_view fmt_str);
 
@@ -58,7 +58,7 @@ void to_string(stream_ref<char> ss, char value);
 void to_string(stream_ref<char> ss, bool value);
 void to_string(stream_ref<char> ss, char const* value);
 void to_string(stream_ref<char> ss, string_view value);
-void to_string(stream_ref<char> ss, nullptr_t);
+void to_string(stream_ref<char> ss, std::nullptr_t);
 
 void to_string(stream_ref<char> ss, void* value);
 
@@ -83,7 +83,7 @@ void to_string(stream_ref<char> ss, char value, string_view fmt_str);
 void to_string(stream_ref<char> ss, bool value, string_view fmt_str);
 void to_string(stream_ref<char> ss, char const* value, string_view fmt_str);
 void to_string(stream_ref<char> ss, string_view value, string_view fmt_str);
-void to_string(stream_ref<char> ss, nullptr_t, string_view fmt_str);
+void to_string(stream_ref<char> ss, std::nullptr_t, string_view fmt_str);
 
 void to_string(stream_ref<char> ss, void* value, string_view fmt_str);
 


### PR DESCRIPTION
* fixes for `cc::format` on linux
* fixes for `cc::as_byte_span` for lvalue refs
* fixes for `string_view` and `span<char const>` interop
* made `span` accept rvalues refs (with CAUTION note)