### PR TITLE
Pt/develop

### DIFF
--- a/src/clean-core/is_contiguous_range.hh
+++ b/src/clean-core/is_contiguous_range.hh
@@ -14,4 +14,6 @@ char contiguous_range_test(...);
 
 template <class Container, class ElementT>
 static constexpr bool is_contiguous_range = sizeof(detail::contiguous_range_test<std::remove_reference_t<Container>, ElementT>(nullptr)) == sizeof(int);
+template <class Container>
+static constexpr bool is_any_contiguous_range = is_contiguous_range<Container, void const>;
 }

--- a/src/clean-core/range_ref.hh
+++ b/src/clean-core/range_ref.hh
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <initializer_list>
+
+#include <clean-core/function_ref.hh>
+#include <clean-core/is_range.hh>
+#include <clean-core/iterator.hh>
+
+namespace cc
+{
+/// a type-erased range of elements that can be converted to T
+template <class T>
+struct range_ref
+{
+    /// empty range
+    range_ref()
+    {
+        _for_each = [](cc::function_ref<void(T)>) {};
+    }
+
+    /// NOTE: make_range_ref is easier to use
+    template <class F, cc::enable_if<std::is_invocable_r_v<void, F, cc::function_ref<void(T)>>> = true>
+    range_ref(F&& for_each_fun)
+    {
+        _for_each = for_each_fun;
+    }
+
+    /// iterates over all elements in the range and calls f for them
+    void for_each(cc::function_ref<void(T)> f) { _for_each(f); }
+
+private:
+    cc::function_ref<void(cc::function_ref<void(T)>)> _for_each;
+};
+
+/// creates an object that can be used as range_ref<T>
+/// CAUTION: the result should be passed directly to a function accepting range_ref<T>
+///          (otherwise one can quickly get lifetime issues)
+template <class T, class Range>
+auto make_range_ref(Range&& range)
+{
+    static_assert(cc::is_any_range<Range>, "only works for ranges");
+    return [&range](cc::function_ref<void(T)> f) {
+        for (auto&& v : range)
+            f(v);
+    };
+};
+/// same as make_range_ref<T> but tries to infer T
+template <class Range>
+auto make_range_ref(Range&& range)
+{
+    static_assert(cc::is_any_range<Range>, "only works for ranges");
+    using T = decltype(*cc::begin(range));
+    return [&range](cc::function_ref<void(T)> f) {
+        for (auto&& v : range)
+            f(v);
+    };
+};
+/// support for cc::make_range_ref({1, 2, 3})
+template <class T>
+auto make_range_ref(std::initializer_list<T> range)
+{
+    // NOTE: capturing range per value is fine as long as its storage outlives the range_ref
+    return [range](cc::function_ref<void(T)> f) {
+        for (auto&& v : range)
+            f(v);
+    };
+}
+}

--- a/src/clean-core/span.hh
+++ b/src/clean-core/span.hh
@@ -36,6 +36,10 @@ public:
 
     explicit constexpr span(T& val) : _data(&val), _size(1) {}
 
+    /// CAUTION: value MUST outlive the span!
+    /// NOTE: this ctor is for spans constructed inside an expression
+    explicit constexpr span(T&& val) : _data(&val), _size(1) {}
+
     constexpr operator span<T const>() const noexcept { return {_data, _size}; }
 
     // container
@@ -101,9 +105,10 @@ private:
 };
 
 // deduction guide for containers
-template <class Container, cc::enable_if<is_contiguous_range<Container, void>> = true>
+template <class Container, cc::enable_if<is_any_contiguous_range<Container>> = true>
 span(Container& c)->span<std::remove_reference_t<decltype(*c.data())>>;
-span(string_view const&)->span<char const>;
+template <class Container, cc::enable_if<is_any_contiguous_range<Container>> = true>
+span(Container&& c)->span<std::remove_reference_t<decltype(*c.data())>>;
 
 /// converts a triv. copyable value, or a container with triv. copyable elements to a cc::span<std::byte>
 template <class T>

--- a/src/clean-core/stream_ref.hh
+++ b/src/clean-core/stream_ref.hh
@@ -60,6 +60,12 @@ private:
 
 /// special case: avoid ambiguous overload by explicitly caring for string literals
 inline stream_ref<char>& operator<<(stream_ref<char>& stream, char const* value) { return stream << string_view(value); }
+/// special case: explicit char arrays need not be null-terminated
+template <size_t N>
+inline stream_ref<char>& operator<<(stream_ref<char>& stream, char const (&value)[N])
+{
+    return stream << string_view(value, N);
+}
 
 /// creates a stream_ref from a given stream
 /// CAUTION: stream must outlive the stream_ref!

--- a/src/clean-core/to_string.cc
+++ b/src/clean-core/to_string.cc
@@ -143,155 +143,155 @@ cc::string cc::to_string(std::byte value)
     return s;
 }
 
-cc::string to_string(char value, cc::string_view fmt_str)
+cc::string cc::to_string(char value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(bool value, cc::string_view fmt_str)
+cc::string cc::to_string(bool value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(char const* value, cc::string_view fmt_str)
+cc::string cc::to_string(char const* value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(cc::string_view value, cc::string_view fmt_str)
+cc::string cc::to_string(cc::string_view value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(std::nullptr_t, cc::string_view fmt_str)
+cc::string cc::to_string(std::nullptr_t, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, std::nullptr_t{}, fmt_str);
     return s;
 }
 
-cc::string to_string(void* value, cc::string_view fmt_str)
+cc::string cc::to_string(void* value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
 
-cc::string to_string(std::byte value, cc::string_view fmt_str)
+cc::string cc::to_string(std::byte value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
 
-cc::string to_string(signed char value, cc::string_view fmt_str)
+cc::string cc::to_string(signed char value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(short value, cc::string_view fmt_str)
+cc::string cc::to_string(short value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(int value, cc::string_view fmt_str)
+cc::string cc::to_string(int value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(long value, cc::string_view fmt_str)
+cc::string cc::to_string(long value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(long long value, cc::string_view fmt_str)
+cc::string cc::to_string(long long value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(unsigned char value, cc::string_view fmt_str)
+cc::string cc::to_string(unsigned char value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(unsigned short value, cc::string_view fmt_str)
+cc::string cc::to_string(unsigned short value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(unsigned int value, cc::string_view fmt_str)
+cc::string cc::to_string(unsigned int value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(unsigned long value, cc::string_view fmt_str)
+cc::string cc::to_string(unsigned long value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
-cc::string to_string(unsigned long long value, cc::string_view fmt_str)
-{
-    cc::string s;
-    to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
-    return s;
-}
-
-cc::string to_string(float value, cc::string_view fmt_str)
-{
-    cc::string s;
-    to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
-    return s;
-}
-cc::string to_string(double value, cc::string_view fmt_str)
-{
-    cc::string s;
-    to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
-    return s;
-}
-cc::string to_string(long double value, cc::string_view fmt_str)
+cc::string cc::to_string(unsigned long long value, cc::string_view fmt_str)
 {
     cc::string s;
     to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
     return s;
 }
 
-void to_string(cc::stream_ref<char> ss, char value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, bool value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, char const* value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, cc::string_view value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, std::nullptr_t) { to_string(ss, std::nullptr_t{}, ""); }
+cc::string cc::to_string(float value, cc::string_view fmt_str)
+{
+    cc::string s;
+    to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
+    return s;
+}
+cc::string cc::to_string(double value, cc::string_view fmt_str)
+{
+    cc::string s;
+    to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
+    return s;
+}
+cc::string cc::to_string(long double value, cc::string_view fmt_str)
+{
+    cc::string s;
+    to_string([&s](cc::span<char const> ss) { s += cc::string_view(ss); }, value, fmt_str);
+    return s;
+}
 
-void to_string(cc::stream_ref<char> ss, void* value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, char value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, bool value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, char const* value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, cc::string_view value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, std::nullptr_t) { to_string(ss, std::nullptr_t{}, ""); }
 
-void to_string(cc::stream_ref<char> ss, std::byte value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, void* value) { to_string(ss, value, ""); }
 
-void to_string(cc::stream_ref<char> ss, signed char value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, short value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, int value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, long value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, long long value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, unsigned char value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, unsigned short value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, unsigned int value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, unsigned long value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, unsigned long long value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, std::byte value) { to_string(ss, value, ""); }
 
-void to_string(cc::stream_ref<char> ss, float value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, double value) { to_string(ss, value, ""); }
-void to_string(cc::stream_ref<char> ss, long double value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, signed char value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, short value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, int value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, long value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, long long value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, unsigned char value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, unsigned short value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, unsigned int value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, unsigned long value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, unsigned long long value) { to_string(ss, value, ""); }
+
+void cc::to_string(cc::stream_ref<char> ss, float value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, double value) { to_string(ss, value, ""); }
+void cc::to_string(cc::stream_ref<char> ss, long double value) { to_string(ss, value, ""); }
 
 namespace
 {


### PR DESCRIPTION
* added `range_ref<T>`
* fixed format on linux
* added `is_any_contiguous_range`
* fixed some `span` deduction guides
* fixed `stream_ref<char>` with char arrays
* added rvalue ref ctor for `span` with appropriate warning
