### PR TITLE
Fix count_leading_zeros behavior

### DIFF
--- a/src/clean-core/alloc_vector.hh
+++ b/src/clean-core/alloc_vector.hh
@@ -12,10 +12,7 @@ struct alloc_vector : public detail::vector_base<T, true>
 public:
     alloc_vector() noexcept : detail::vector_base<T, true>(cc::system_allocator) {}
 
-    explicit alloc_vector(cc::allocator* allocator) noexcept : detail::vector_base<T, true>(allocator)
-    {
-        CC_CONTRACT(allocator != nullptr);
-    }
+    explicit alloc_vector(cc::allocator* allocator) noexcept : detail::vector_base<T, true>(allocator) { CC_CONTRACT(allocator != nullptr); }
 
     explicit alloc_vector(size_t size, cc::allocator* allocator = cc::system_allocator) : alloc_vector(allocator)
     {

--- a/src/clean-core/unique_function.hh
+++ b/src/clean-core/unique_function.hh
@@ -53,7 +53,7 @@ public:
 
     ~unique_function() { _destroy(); }
 
-    unique_function(unique_function&& rhs) noexcept : _func(rhs._func), _deleter(rhs._deleter), _context(rhs._context), _alloc(rhs._alloc)
+    unique_function(unique_function&& rhs) noexcept : _func(rhs._func), _deleter(rhs._deleter), _alloc(rhs._alloc), _context(rhs._context)
     {
         rhs._context = nullptr;
     }


### PR DESCRIPTION
Fixes two different inconsistencies regarding cc::count_leading_zeros:
    - win32: properly falls back on BSR/XOR+ check for 0 if target arch does not support lzcnt
    - linux: properly falls back on builtin_clz + check for 0 if target arch does not support lzcnt
Also added a runtime cpu support test and some comments explaining this mess