### PR TITLE
Alloc container changes, bit helper overloads

### DIFF
--- a/src/clean-core/alloc_array.hh
+++ b/src/clean-core/alloc_array.hh
@@ -16,9 +16,7 @@ namespace cc
 template <class T>
 struct alloc_array
 {
-    static_assert(sizeof(T) > 0, "cannot make alloc_array of incomplete object");
-
-    alloc_array() : _allocator(cc::system_allocator) {}
+    alloc_array() : _allocator(cc::system_allocator) { static_assert(sizeof(T) > 0, "cannot make alloc_array of incomplete object"); }
 
     explicit alloc_array(cc::allocator* allocator) : _allocator(allocator) { CC_CONTRACT(allocator != nullptr); }
 
@@ -87,7 +85,11 @@ struct alloc_array
     alloc_array(alloc_array const& a) = delete;
     alloc_array& operator=(alloc_array const& a) = delete;
 
-    ~alloc_array() { _destroy(); }
+    ~alloc_array()
+    {
+        static_assert(sizeof(T) > 0, "alloc_array destructor requires complete type");
+        _destroy();
+    }
 
     void resize(size_t new_size, T const& value = {})
     {

--- a/src/clean-core/alloc_vector.hh
+++ b/src/clean-core/alloc_vector.hh
@@ -95,6 +95,26 @@ public:
 
     alloc_vector(alloc_vector const& rhs) = delete;
     alloc_vector& operator=(alloc_vector const& rhs) = delete;
+
+    /// destroy contents, reset to a new allocator and reserve
+    void reset_reserve(cc::allocator* new_allocator, size_t reserve_size)
+    {
+        // destroy
+        if (this->_data)
+        {
+            detail::container_destroy_reverse<T>(this->_data, this->_size);
+            this->_free(this->_data);
+            this->_data = nullptr;
+            this->_size = 0;
+            this->_capacity = 0;
+        }
+        // now in moved-from state
+
+        // reset allocator and reserve
+        CC_CONTRACT(new_allocator != nullptr);
+        this->_allocator = new_allocator;
+        this->reserve(reserve_size);
+    }
 };
 
 // hash

--- a/src/clean-core/allocator.cc
+++ b/src/clean-core/allocator.cc
@@ -155,6 +155,9 @@ cc::byte* cc::system_allocator_t::realloc(void* ptr, cc::size_t old_size, cc::si
 #endif
 }
 
+cc::system_allocator_t cc::system_allocator_instance = {};
+cc::allocator* const cc::system_allocator = &cc::system_allocator_instance;
+
 cc::byte* cc::allocator::realloc(void* ptr, cc::size_t old_size, cc::size_t new_size, cc::size_t align)
 {
     cc::byte* res = nullptr;

--- a/src/clean-core/allocator.hh
+++ b/src/clean-core/allocator.hh
@@ -119,7 +119,7 @@ public:
 };
 
 inline cc::system_allocator_t system_allocator_instance;
-inline constexpr cc::allocator* const system_allocator = &system_allocator_instance;
+inline cc::allocator* const system_allocator = &system_allocator_instance;
 
 //
 // implementation below

--- a/src/clean-core/allocator.hh
+++ b/src/clean-core/allocator.hh
@@ -118,8 +118,8 @@ public:
     system_allocator_t() = default;
 };
 
-inline cc::system_allocator_t system_allocator_instance;
-inline cc::allocator* const system_allocator = &system_allocator_instance;
+extern cc::system_allocator_t system_allocator_instance;
+extern allocator* const system_allocator;
 
 //
 // implementation below

--- a/src/clean-core/bits.hh
+++ b/src/clean-core/bits.hh
@@ -151,12 +151,18 @@ inline uint64 ceil_pow2(uint64 v) { return uint64(1) << (bit_log2(v - uint64(1))
 constexpr bool is_pow2(uint32 v) { return ((v & (v - uint32(1))) == 0); }
 constexpr bool is_pow2(uint64 v) { return ((v & (v - uint64(1))) == 0); }
 
+constexpr void set_bit(uint8& val, uint32 bit_idx) { val |= (uint8(1) << bit_idx); }
+constexpr void set_bit(uint16& val, uint32 bit_idx) { val |= (uint16(1) << bit_idx); }
 constexpr void set_bit(uint32& val, uint32 bit_idx) { val |= (uint32(1) << bit_idx); }
 constexpr void set_bit(uint64& val, uint32 bit_idx) { val |= (uint64(1) << bit_idx); }
 
+constexpr void unset_bit(uint8& val, uint32 bit_idx) { val &= ~(uint8(1) << bit_idx); }
+constexpr void unset_bit(uint16& val, uint32 bit_idx) { val &= ~(uint16(1) << bit_idx); }
 constexpr void unset_bit(uint32& val, uint32 bit_idx) { val &= ~(uint32(1) << bit_idx); }
 constexpr void unset_bit(uint64& val, uint32 bit_idx) { val &= ~(uint64(1) << bit_idx); }
 
+constexpr void flip_bit(uint8& val, uint32 bit_idx) { val ^= (uint8(1) << bit_idx); }
+constexpr void flip_bit(uint16& val, uint32 bit_idx) { val ^= (uint16(1) << bit_idx); }
 constexpr void flip_bit(uint32& val, uint32 bit_idx) { val ^= (uint32(1) << bit_idx); }
 constexpr void flip_bit(uint64& val, uint32 bit_idx) { val ^= (uint64(1) << bit_idx); }
 }

--- a/src/clean-core/fwd.hh
+++ b/src/clean-core/fwd.hh
@@ -93,4 +93,5 @@ struct poly_unique_ptr;
 
 // allocators
 struct allocator;
+extern allocator* const system_allocator;
 }

--- a/src/clean-core/native/wchar_conversion.hh
+++ b/src/clean-core/native/wchar_conversion.hh
@@ -5,12 +5,12 @@
 namespace cc
 {
 /// converts a wchar_t string to a (UTF-8) char string
-/// opt_num_src_chars can be specified to stop conversion before '\0' terminateion
+/// opt_num_src_chars can be specified to stop conversion before '\0' termination
 /// returns amount of characters written to dest
 int widechar_to_char(cc::span<char> dest, wchar_t const* src, int opt_num_src_chars = -1);
 
 /// converts a (UTF-8) char string to a wchar_t string
-/// opt_num_src_chars can be specified to stop conversion before '\0' terminateion
+/// opt_num_src_chars can be specified to stop conversion before '\0' termination
 /// returns amount of characters written to dest
 int char_to_widechar(cc::span<wchar_t> dest, char const* src, int opt_num_src_chars = -1);
 }


### PR DESCRIPTION
- Make alloc_array compatible with forward declared Ts
- Add alloc_vector::reset_reserve
- Add u8/u16 overloads to set/unset/flip bit helpers