### PR TITLE
vector::push_back_span, alloc_array::reset, win32 util

### DIFF
--- a/src/clean-core/alloc_array.hh
+++ b/src/clean-core/alloc_array.hh
@@ -140,13 +140,6 @@ struct alloc_array
             new (placement_new, &_data[i]) T(value);
     }
 
-    void write_bytes(cc::span<std::byte const> src_data, size_t offset_bytes = 0)
-    {
-        static_assert(std::is_trivially_copyable_v<T> && std::is_trivially_destructible_v<T>, "write_bytes requires trivial copy and dtor");
-        CC_ASSERT(offset_bytes + src_data.size_bytes() <= _size * sizeof(T) && "write out of bounds");
-        std::memcpy(reinterpret_cast<std::byte*>(_data) + offset_bytes, src_data.data(), src_data.size_bytes());
-    }
-
     constexpr T* begin() { return _data; }
     constexpr T* end() { return _data + _size; }
     constexpr T const* begin() const { return _data; }

--- a/src/clean-core/alloc_array.hh
+++ b/src/clean-core/alloc_array.hh
@@ -140,6 +140,13 @@ struct alloc_array
             new (placement_new, &_data[i]) T(value);
     }
 
+    void write_bytes(cc::span<std::byte const> src_data, size_t offset_bytes = 0)
+    {
+        static_assert(std::is_trivially_copyable_v<T> && std::is_trivially_destructible_v<T>, "write_bytes requires trivial copy and dtor");
+        CC_ASSERT(offset_bytes + src_data.size_bytes() <= _size * sizeof(T) && "write out of bounds");
+        std::memcpy(reinterpret_cast<std::byte*>(_data) + offset_bytes, src_data.data(), src_data.size_bytes());
+    }
+
     constexpr T* begin() { return _data; }
     constexpr T* end() { return _data + _size; }
     constexpr T const* begin() const { return _data; }

--- a/src/clean-core/alloc_array.hh
+++ b/src/clean-core/alloc_array.hh
@@ -91,7 +91,27 @@ struct alloc_array
         _destroy();
     }
 
-    void reset(cc::allocator* new_allocator, size_t new_size = 0, T const& new_value = {})
+    void reset(cc::allocator* new_allocator, size_t new_size = 0)
+    {
+        _destroy();
+
+        CC_CONTRACT(new_allocator != nullptr);
+        _allocator = new_allocator;
+        _size = new_size;
+
+        if (new_size > 0)
+        {
+            _data = _alloc(new_size);
+            for (size_t i = 0; i < new_size; ++i)
+                new (placement_new, &_data[i]) T();
+        }
+        else
+        {
+            _data = nullptr;
+        }
+    }
+
+    void reset(cc::allocator* new_allocator, size_t new_size, T const& new_value)
     {
         _destroy();
 

--- a/src/clean-core/alloc_array.hh
+++ b/src/clean-core/alloc_array.hh
@@ -91,6 +91,26 @@ struct alloc_array
         _destroy();
     }
 
+    void reset(cc::allocator* new_allocator, size_t new_size = 0, T const& new_value = {})
+    {
+        _destroy();
+
+        CC_CONTRACT(new_allocator != nullptr);
+        _allocator = new_allocator;
+        _size = new_size;
+
+        if (new_size > 0)
+        {
+            _data = _alloc(new_size);
+            for (size_t i = 0; i < new_size; ++i)
+                new (placement_new, &_data[i]) T(new_value);
+        }
+        else
+        {
+            _data = nullptr;
+        }
+    }
+
     void resize(size_t new_size, T const& value = {})
     {
         _destroy();

--- a/src/clean-core/bits.hh
+++ b/src/clean-core/bits.hh
@@ -148,8 +148,13 @@ inline uint64 bit_log2(uint64 v) { return uint64(8 * sizeof(uint64) - count_lead
 inline uint32 ceil_pow2(uint32 v) { return uint32(1) << (bit_log2(v - uint32(1)) + 1); }
 inline uint64 ceil_pow2(uint64 v) { return uint64(1) << (bit_log2(v - uint64(1)) + 1); }
 
+// returns true if v is a power of 2
 constexpr bool is_pow2(uint32 v) { return ((v & (v - uint32(1))) == 0); }
 constexpr bool is_pow2(uint64 v) { return ((v & (v - uint64(1))) == 0); }
+
+// computes v % divisor, divisor must be a power of 2
+constexpr uint32 mod_pow2(uint32 v, uint32 divisor) { return v & (divisor - 1); }
+constexpr uint64 mod_pow2(uint64 v, uint64 divisor) { return v & (divisor - 1); }
 
 constexpr void set_bit(uint8& val, uint32 bit_idx) { val |= (uint8(1) << bit_idx); }
 constexpr void set_bit(uint16& val, uint32 bit_idx) { val |= (uint16(1) << bit_idx); }

--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -149,6 +149,24 @@ public:
     /// adds an element at the end
     T& push_back(T&& value) { return emplace_back(cc::move(value)); }
 
+    /// adds multiple elements at the end
+    void push_back_span(cc::span<T const> value_range)
+    {
+        this->reserve(_size + value_range.size());
+        if constexpr (std::is_trivially_copyable_v<T> && std::is_trivially_destructible_v<T>)
+        {
+            std::memcpy(&_data[_size], value_range.data(), value_range.size_bytes());
+            _size += value_range.size();
+        }
+        else
+        {
+            for (T const& val : value_range)
+            {
+                emplace_back(val);
+            }
+        }
+    }
+
     /// removes the last element
     void pop_back()
     {

--- a/src/clean-core/native/win32_util.cc
+++ b/src/clean-core/native/win32_util.cc
@@ -1,0 +1,124 @@
+#include "win32_util.hh"
+
+#include <clean-core/macros.hh>
+
+#ifdef CC_OS_WINDOWS
+
+#include <clean-core/defer.hh>
+
+#include <clean-core/native/win32_sanitized.hh>
+
+bool cc::win32_get_version(unsigned& out_major, unsigned& out_minor, unsigned& out_build_number)
+{
+    // getting the current windows version is not as straightforward as it once was,
+    // since GetVersion and GetVersionEx are deprecated and the Win32 Version Helper functions
+    // will lie about the OS version depending on the manifest file.
+    // They also give no direct information about the build number (which corresponds to "Windows 10 Versions"
+    // like 1904, 1909, 2004, ..., or their marketing names like "Fall Creators Update", "May 2020 Update", ...)
+    // which nowadays is often the only part of real interest
+
+    // there are several approaches, this one is using the ancient,
+    // undocumented NTDLL function RtlGetNtVersionNumbers
+    // out parameters are "major number", "minor number" and "build number"
+    // the build number must be masked to the lower 16 bit,
+    // as the high bits contain additional information about it being a checked/free build
+
+    // see
+    //  http://www.geoffchappell.com/studies/windows/win32/ntdll/api/ldrinit/getntversionnumbers.htm
+    //  https://stackoverflow.com/questions/47581146/getting-os-build-version-from-win32-api-c
+
+    HMODULE hModule = GetModuleHandle(TEXT("ntdll.dll"));
+
+    if (hModule == NULL)
+        return false;
+
+    typedef VOID(WINAPI * RtlGetNtVersionNumbersPtr)(DWORD*, DWORD*, DWORD*);
+    auto const f_RtlGetNtVersionNumbers = (RtlGetNtVersionNumbersPtr)::GetProcAddress(hModule, "RtlGetNtVersionNumbers");
+
+    if (f_RtlGetNtVersionNumbers == nullptr)
+        return false;
+
+    DWORD major_version, minor_version, build_number;
+    f_RtlGetNtVersionNumbers(&major_version, &minor_version, &build_number);
+
+    out_major = major_version;
+    out_minor = minor_version;
+    out_build_number = build_number & 0x0000FFFF;
+    return true;
+}
+
+bool cc::win32_enable_schedular_granular()
+{
+    // Barely documented behavior of timeBeginPeriod,
+    // sets the OS scheduler timeslice to the given value in milliseconds
+    // in practice an argument of 1 ends up at ~.7ms
+    // see:
+    //   https://docs.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod
+    //   https://hero.handmade.network/episode/code/day018/#3200
+
+    // This change is global and should be undone at shutdown
+    // It should not be called often (ideally just once)
+
+    HMODULE hModWinmm = LoadLibrary("Winmm.dll");
+
+    if (hModWinmm == NULL)
+        return false;
+
+    CC_DEFER { ::FreeLibrary(hModWinmm); };
+
+    typedef UINT(WINAPI * timeBeginPeriodPtr)(_In_ UINT);
+    auto const f_timeBeginPeriod = (timeBeginPeriodPtr)::GetProcAddress(hModWinmm, "timeBeginPeriod");
+
+    if (f_timeBeginPeriod == nullptr)
+        return false;
+
+    return f_timeBeginPeriod(1) == 0 /*TIMERR_NOERROR*/;
+}
+
+bool cc::win32_disable_scheduler_granular()
+{
+    // Undos the change to the OS scheduler, the "period" specified must
+    // be the same as in the first call
+
+    HMODULE hModWinmm = LoadLibrary("Winmm.dll");
+
+    if (hModWinmm == NULL)
+        return false;
+
+    CC_DEFER { ::FreeLibrary(hModWinmm); };
+
+    typedef UINT(WINAPI * timeEndPeriodPtr)(_In_ UINT);
+    auto const f_timeEndPeriod = (timeEndPeriodPtr)::GetProcAddress(hModWinmm, "timeEndPeriod");
+
+    if (f_timeEndPeriod == nullptr)
+        return false;
+
+    return f_timeEndPeriod(1) == 0 /*TIMERR_NOERROR*/;
+}
+
+
+bool cc::win32_enable_console_colors()
+{
+    ::HANDLE const console_handle = ::GetStdHandle(STD_OUTPUT_HANDLE);
+    if (console_handle == INVALID_HANDLE_VALUE)
+        return false;
+
+    ::DWORD prev_mode;
+    if (!::GetConsoleMode(console_handle, &prev_mode))
+        return false;
+
+    prev_mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    if (!::SetConsoleMode(console_handle, prev_mode))
+        return false;
+
+    return true;
+}
+
+#else
+
+bool cc::win32_get_version(unsigned&, unsigned&, unsigned&) { return false; }
+bool cc::win32_enable_schedular_granular() { return false; }
+bool cc::win32_disable_scheduler_granular() { return false; }
+bool cc::win32_enable_console_colors() { return false; }
+
+#endif

--- a/src/clean-core/native/win32_util.hh
+++ b/src/clean-core/native/win32_util.hh
@@ -8,14 +8,4 @@ namespace cc
 /// for a list of build numbers and corresponding "versions" and marketing names, see
 ///   https://en.wikipedia.org/wiki/Windows_10_version_history#Channels
 bool win32_get_version(unsigned& out_major, unsigned& out_minor, unsigned& out_build_number);
-
-/// attempts to increase the OS scheduler timeslice to the minimum amount (~.7ms) using timeBeginPeriod
-/// this change is global for the entire OS and should be undone at shutdown
-bool win32_enable_schedular_granular();
-
-/// undos the change made above
-bool win32_disable_scheduler_granular();
-
-/// enables ANSI Escape sequences in Windows conhost.exe and cmd.exe
-bool win32_enable_console_colors();
 }

--- a/src/clean-core/native/win32_util.hh
+++ b/src/clean-core/native/win32_util.hh
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace cc
+{
+/// reads the true windows version using the undocumented RtlGetNtVersionNumbers NTDLL kernel function
+///
+/// output example on Win10 2004: { major: 10, minor: 0, build_number: 19041 }
+/// for a list of build numbers and corresponding "versions" and marketing names, see
+///   https://en.wikipedia.org/wiki/Windows_10_version_history#Channels
+bool win32_get_version(unsigned& out_major, unsigned& out_minor, unsigned& out_build_number);
+
+/// attempts to increase the OS scheduler timeslice to the minimum amount (~.7ms) using timeBeginPeriod
+/// this change is global for the entire OS and should be undone at shutdown
+bool win32_enable_schedular_granular();
+
+/// undos the change made above
+bool win32_disable_scheduler_granular();
+
+/// enables ANSI Escape sequences in Windows conhost.exe and cmd.exe
+bool win32_enable_console_colors();
+}


### PR DESCRIPTION
- Added `alloc_array::reset`, similar to `alloc_vector::reset_reserve`
- Added `alloc_array::write_bytes` as a range-checked memcpy
- Added `vector::push_back_span`, efficiently reserves up front and memcpies if possible (also affects `alloc_vector`
- Added `native/win32_util.hh` with a util to obtain the true windows version using undocumented NT functions
