### PR TITLE
add inline keyword to CC_FORCE_INLINE macro

### DIFF
--- a/src/clean-core/macros.hh
+++ b/src/clean-core/macros.hh
@@ -67,7 +67,7 @@
 
 #define CC_PRETTY_FUNC __PRETTY_FUNCTION__
 
-#define CC_FORCE_INLINE __attribute__((always_inline))
+#define CC_FORCE_INLINE __attribute__((always_inline)) inline
 #define CC_DONT_INLINE __attribute__((noinline))
 
 #define CC_LIKELY(x) __builtin_expect((x), 1)


### PR DESCRIPTION
gcc warns about "always_inline function might not be inlinable"
otherwise.
https://stackoverflow.com/questions/32432596/warning-always-inline-function-might-not-be-inlinable-wattributes