### PR TITLE
Kw/develop

### DIFF
--- a/src/clean-core/allocator.hh
+++ b/src/clean-core/allocator.hh
@@ -135,6 +135,7 @@ constexpr size_t get_array_padding(size_t elem_size)
 template <class T, class... Args>
 T* allocator::new_t(Args&&... args)
 {
+    static_assert(sizeof(T) > 0, "cannot construct incomplete type");
     auto* const buf = this->alloc(sizeof(T), alignof(T));
     return new (placement_new, buf) T(cc::forward<Args>(args)...);
 }
@@ -142,6 +143,7 @@ T* allocator::new_t(Args&&... args)
 template <class T>
 void allocator::delete_t(T* ptr)
 {
+    static_assert(sizeof(T) > 0, "cannot destruct incomplete type");
     if (ptr == nullptr)
         return;
 
@@ -154,6 +156,7 @@ void allocator::delete_t(T* ptr)
 template <class T>
 T* allocator::new_array(size_t num_elems)
 {
+    static_assert(sizeof(T) > 0, "cannot construct incomplete type");
     constexpr size_t padding = detail::get_array_padding(sizeof(T));
     size_t size = sizeof(T) * num_elems + padding;
 
@@ -171,6 +174,7 @@ T* allocator::new_array(size_t num_elems)
 template <class T>
 void allocator::delete_array(T* ptr)
 {
+    static_assert(sizeof(T) > 0, "cannot destruct incomplete type");
     if (ptr == nullptr)
         return;
 
@@ -190,6 +194,7 @@ void allocator::delete_array(T* ptr)
 template <class T>
 T* allocator::new_array_sized(size_t num_elems)
 {
+    static_assert(sizeof(T) > 0, "cannot construct incomplete type");
     T* const res_array_ptr = reinterpret_cast<T*>(this->alloc(sizeof(T) * num_elems, alignof(T)));
     for (auto i = 0u; i < num_elems; ++i)
         new (placement_new, res_array_ptr + i) T();
@@ -200,6 +205,7 @@ T* allocator::new_array_sized(size_t num_elems)
 template <class T>
 void allocator::delete_array_sized(T* ptr, cc::size_t num_elems)
 {
+    static_assert(sizeof(T) > 0, "cannot destruct incomplete type");
     if (ptr == nullptr)
         return;
 

--- a/src/clean-core/assert.cc
+++ b/src/clean-core/assert.cc
@@ -32,9 +32,11 @@ void default_assertion_handler(cc::detail::assertion_info const& info)
 
     // TODO: stacktrace
 
-#ifndef CC_RELEASE
+#if !defined(CC_RELEASE) && !defined(CC_OS_WINDOWS)
+    // on win32, this suppresses the CRT abort/retry debugger attach message
     cc::breakpoint();
 #endif
+
     std::abort();
 }
 } // namespace

--- a/src/clean-core/bits.hh
+++ b/src/clean-core/bits.hh
@@ -170,4 +170,9 @@ constexpr void flip_bit(uint8& val, uint32 bit_idx) { val ^= (uint8(1) << bit_id
 constexpr void flip_bit(uint16& val, uint32 bit_idx) { val ^= (uint16(1) << bit_idx); }
 constexpr void flip_bit(uint32& val, uint32 bit_idx) { val ^= (uint32(1) << bit_idx); }
 constexpr void flip_bit(uint64& val, uint32 bit_idx) { val ^= (uint64(1) << bit_idx); }
+
+constexpr bool has_bit(uint8 val, uint32 bit_idx) { return (val & (uint8(1) << bit_idx)) != 0; }
+constexpr bool has_bit(uint16 val, uint32 bit_idx) { return (val & (uint16(1) << bit_idx)) != 0; }
+constexpr bool has_bit(uint32 val, uint32 bit_idx) { return (val & (uint32(1) << bit_idx)) != 0; }
+constexpr bool has_bit(uint64 val, uint32 bit_idx) { return (val & (uint64(1) << bit_idx)) != 0; }
 }

--- a/src/clean-core/span.hh
+++ b/src/clean-core/span.hh
@@ -5,7 +5,6 @@
 
 #include <clean-core/assert.hh>
 #include <clean-core/enable_if.hh>
-#include <clean-core/fwd.hh>
 #include <clean-core/is_contiguous_range.hh>
 #include <clean-core/typedefs.hh>
 
@@ -22,11 +21,7 @@ struct span
 public:
     constexpr span() = default;
 
-    // prevent the templated constructor to hijack copy
-    constexpr span(span const& rhs) noexcept = default;
-
     CC_FORCE_INLINE constexpr span(T* data, size_t size) : _data(data), _size(size) {}
-
     CC_FORCE_INLINE constexpr span(T* d_begin, T* d_end) : _data(d_begin), _size(d_end - d_begin) {}
 
     template <size_t N>
@@ -144,6 +139,7 @@ private:
     T* _data = nullptr;
     size_t _size = 0;
 };
+
 
 // deduction guide for containers
 template <class Container, cc::enable_if<is_any_contiguous_range<Container>> = true>

--- a/src/clean-core/span.hh
+++ b/src/clean-core/span.hh
@@ -20,27 +20,33 @@ struct span
     // ctors
 public:
     constexpr span() = default;
-    constexpr span(T* data, size_t size) : _data(data), _size(size) {}
-    constexpr span(T* d_begin, T* d_end) : _data(d_begin), _size(d_end - d_begin) {}
+
+    // prevent the templated constructor to hijack copy
+    constexpr span(span const& rhs) noexcept = default;
+
+    CC_FORCE_INLINE constexpr span(T* data, size_t size) : _data(data), _size(size) {}
+
+    CC_FORCE_INLINE constexpr span(T* d_begin, T* d_end) : _data(d_begin), _size(d_end - d_begin) {}
+
     template <size_t N>
-    constexpr span(T (&data)[N]) : _data(data), _size(N)
+    CC_FORCE_INLINE constexpr span(T (&data)[N]) : _data(data), _size(N)
     {
     }
 
     /// generic span constructor from contiguous_range
     /// CAUTION: container MUST outlive the span!
     template <class Container, cc::enable_if<is_contiguous_range<Container, T>> = true>
-    constexpr span(Container&& c) : _data(c.data()), _size(c.size())
+    CC_FORCE_INLINE constexpr span(Container&& c) : _data(c.data()), _size(c.size())
     {
     }
 
-    explicit constexpr span(T& val) : _data(&val), _size(1) {}
+    CC_FORCE_INLINE explicit constexpr span(T& val) : _data(&val), _size(1) {}
 
     /// CAUTION: value MUST outlive the span!
     /// NOTE: this ctor is for spans constructed inside an expression
-    explicit constexpr span(T&& val) : _data(&val), _size(1) {}
+    CC_FORCE_INLINE explicit constexpr span(T&& val) : _data(&val), _size(1) {}
 
-    constexpr operator span<T const>() const noexcept { return {_data, _size}; }
+    CC_FORCE_INLINE constexpr operator span<T const>() const noexcept { return {_data, _size}; }
 
     // container
 public:


### PR DESCRIPTION
- `cc::has_bit(value, index)` (bits.hh)
- require complete types for `cc::allocator` virtual new/delete variants
- improve assert trigger behavior in debug configs on win32