### PR TITLE
Fix cc::placement_new for array new[]

### DIFF
--- a/src/clean-core/capped_array.hh
+++ b/src/clean-core/capped_array.hh
@@ -54,7 +54,7 @@ public:
     constexpr capped_array(size_t size) : _size(compact_size_t(size))
     {
         CC_CONTRACT(size <= N);
-        new (&_u.value[0]) T[size]();
+        new (placement_new, &_u.value[0]) T[size]();
     }
 
     constexpr capped_array(std::initializer_list<T> data)

--- a/src/clean-core/new.hh
+++ b/src/clean-core/new.hh
@@ -16,4 +16,5 @@ static constexpr cc::detail::placement_new_tag placement_new;
 /// Usage:
 /// T* ptr = new(cc::placement_new, memory) T();
 inline void* operator new(size_t, cc::detail::placement_new_tag, void* buffer) { return buffer; }
+inline void* operator new[](size_t, cc::detail::placement_new_tag, void* buffer) { return buffer; }
 inline void operator delete(void*, cc::detail::placement_new_tag, void*) {}


### PR DESCRIPTION
This fixes compilation for clang 9