### PR TITLE
cc::scratch_allocator, int_ceil_to_multiple

### DIFF
--- a/src/clean-core/allocator.cc
+++ b/src/clean-core/allocator.cc
@@ -1,10 +1,23 @@
 #include <clean-core/allocator.hh>
 
+#include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 
 #include <clean-core/assert.hh>
 #include <clean-core/utility.hh>
+
+// enable debug trace printfs in some allocators
+#define CC_DEBUG_TRACE_SCRATCH_ALLOC 0
+
+#if CC_DEBUG_TRACE_SCRATCH_ALLOC
+#define CC_DTRACE_ALLOC_PRINTF printf
+#define CC_DTRACE_ALLOC_FFLUSH() fflush(stdout)
+#else
+#define CC_DTRACE_ALLOC_PRINTF(...) (void)0
+#define CC_DTRACE_ALLOC_FFLUSH() (void)0
+#endif
 
 namespace
 {
@@ -13,21 +26,18 @@ struct stack_alloc_header
     size_t padding;
 };
 
-template <class T>
-[[nodiscard]] T align_up_masked(T value, size_t mask)
+struct scratch_alloc_header
 {
-    return (T)(((size_t)value + mask) & ~mask);
-}
+    uint32_t size;
+};
 
-template <class T>
-[[nodiscard]] T align_up(T value, size_t alignment)
-{
-    return align_up_masked(value, alignment - 1);
-}
+constexpr uint32_t const gc_header_pad_value = 0xffffffffu;
+constexpr uint32_t const gc_header_free_bit = 0x80000000u;
 
+// [... pad ...] [header] [data]
 std::byte* align_up_with_header(std::byte* head, size_t align, size_t header_size)
 {
-    std::byte* padded_res = align_up(head, align);
+    std::byte* padded_res = cc::align_up(head, align);
     size_t const padding = size_t(padded_res - head);
 
     if (padding < header_size)
@@ -47,11 +57,36 @@ std::byte* align_up_with_header(std::byte* head, size_t align, size_t header_siz
 
     return padded_res;
 }
+
+// [header] [... pad ...] [data]
+std::byte* align_up_from_header(scratch_alloc_header* header, size_t align)
+{
+    void* const p = header + 1;
+    return static_cast<std::byte*>(cc::align_up(p, align));
+}
+
+// returns a pointer to the header preceding the given allocation
+scratch_alloc_header* get_header_before_pointer(void* ptr)
+{
+    uint32_t* p = (uint32_t*)ptr;
+    while (p[-1] == gc_header_pad_value)
+        --p;
+    return (scratch_alloc_header*)p - 1;
+}
+
+// writes the size of an allocation to a header, and 0xFF to the bytes between the header and the allocation
+void fill_in_header_value(scratch_alloc_header* header, void* associated_data_ptr, uint32_t size)
+{
+    header->size = size;
+    uint32_t* p = (uint32_t*)(header + 1);
+    while (p < associated_data_ptr)
+        *p++ = gc_header_pad_value;
+}
 }
 
 cc::byte* cc::linear_allocator::alloc(cc::size_t size, cc::size_t align)
 {
-    CC_ASSERT(_buffer != nullptr && "linear_allocator uninitialized");
+    CC_ASSERT(_buffer_begin != nullptr && "linear_allocator uninitialized");
 
     auto* const padded_res = align_up(_head, align);
 
@@ -63,13 +98,15 @@ cc::byte* cc::linear_allocator::alloc(cc::size_t size, cc::size_t align)
 
 cc::byte* cc::stack_allocator::alloc(cc::size_t size, cc::size_t align)
 {
-    CC_ASSERT(_buffer != nullptr && "stack_allocator uninitialized");
+    CC_ASSERT(_buffer_begin != nullptr && "stack_allocator uninitialized");
 
     auto* const padded_res = align_up_with_header(_head, align, sizeof(stack_alloc_header));
 
     CC_ASSERT(padded_res + size <= _buffer_end && "stack_allocator overcommitted");
 
-    stack_alloc_header const header{size_t(padded_res - _head)};
+    stack_alloc_header header = {};
+    header.padding = size_t(padded_res - _head);
+
     std::memcpy(padded_res - sizeof(header), &header, sizeof(header));
 
     _head = padded_res + size;
@@ -86,6 +123,7 @@ void cc::stack_allocator::free(void* ptr)
 
     std::byte* const byte_ptr = static_cast<std::byte*>(ptr);
     stack_alloc_header const* const alloc_header = (stack_alloc_header*)(byte_ptr - sizeof(stack_alloc_header));
+
     _head = byte_ptr - alloc_header->padding;
 }
 
@@ -188,4 +226,125 @@ cc::byte* cc::allocator::realloc_request(void* ptr, cc::size_t old_size, cc::siz
     CC_UNUSED(request_size);
     out_received_size = new_min_size;
     return this->realloc(ptr, old_size, new_min_size, align);
+}
+
+cc::byte* cc::scratch_allocator::alloc(cc::size_t size, cc::size_t align)
+{
+    CC_DTRACE_ALLOC_PRINTF("    [alloc]    call - size %zu, align %zu\n", size, align);
+
+    size = int_ceil_to_multiple<size_t>(size, 4);
+
+    byte* p = _head;
+    scratch_alloc_header* h = reinterpret_cast<scratch_alloc_header*>(p);
+    byte* data = align_up_from_header(h, align); // points to after the header, aligned
+    p = data + size;                             // end of planned allocation
+
+    // end would be OOB, wrap around to start of ring
+    if (p > _buffer_end)
+    {
+        // write wraparound marker to the header
+        CC_ASSERT(reinterpret_cast<byte*>(h) < _buffer_end && "programmer error");
+        uint32_t const num_bytes_until_end = uint32_t(_buffer_end - reinterpret_cast<byte*>(h));
+
+        CC_DTRACE_ALLOC_PRINTF("    [alloc]    %zu bytes would wrap, writing %u to wraparound header [%u]\n", size, num_bytes_until_end, get_ptr_offset(h));
+
+        h->size = (num_bytes_until_end | gc_header_free_bit);
+
+        p = _buffer_begin;
+        h = reinterpret_cast<scratch_alloc_header*>(p);
+        data = align_up_from_header(h, align); // points to after the header, aligned
+        p = data + size;                       // end of planned allocation
+    }
+
+    if (p > _buffer_end || in_use(p))
+    {
+        // ring buffer is exhausted, use fallback
+        CC_ASSERT(_backing_alloc != nullptr && "scratch_allocator out of memory and no backing allocator present");
+        return _backing_alloc->alloc(size, align);
+    }
+
+    // write size to the header
+    uint32 const allocsize = static_cast<uint32>(p - reinterpret_cast<byte*>(h));
+    fill_in_header_value(h, data, allocsize);
+    _head = p;
+
+    if (_head == _buffer_end)
+    {
+        // head is at end of the buffer, and would never be reached by the free loop, wrap to begin
+        _head = _buffer_begin;
+    }
+
+    CC_DTRACE_ALLOC_PRINTF("    [alloc]    head: %u, writing %u to header [%u]\n", get_ptr_offset(_head), allocsize, get_ptr_offset(h));
+    CC_DTRACE_ALLOC_FFLUSH();
+
+
+    return data;
+}
+
+void cc::scratch_allocator::free(void* ptr)
+{
+    if (ptr == nullptr)
+        return;
+
+
+    // free from backing allocator if not in own ring buffer
+    if (ptr < _buffer_begin || ptr > _buffer_end)
+    {
+        CC_ASSERT(_backing_alloc != nullptr && "freed out of bounds pointer with scratch allocator and no backing allocator present that could be the source of it");
+        _backing_alloc->free(ptr);
+        return;
+    }
+
+    // mark header of freed slot as free
+    scratch_alloc_header* const h = get_header_before_pointer(ptr);
+
+    CC_DTRACE_ALLOC_PRINTF("    [free]     freeing %u, entering loop (tail: %u, head: %u)\n", get_ptr_offset(h), get_ptr_offset(_tail), get_ptr_offset(_head));
+
+    CC_ASSERT((h->size & gc_header_free_bit) == 0 && "scratch_allocator double free");
+    h->size = h->size | gc_header_free_bit;
+
+
+    // advance tail past all free slots
+    while (_tail != _head)
+    {
+        scratch_alloc_header const* const slot_h = reinterpret_cast<scratch_alloc_header*>(_tail);
+
+        // break once a non-free slot was reached
+        if ((slot_h->size & gc_header_free_bit) == 0)
+        {
+            CC_DTRACE_ALLOC_PRINTF("    [free]     reached non-free header [%u] (break)\n", get_ptr_offset(slot_h));
+            CC_DTRACE_ALLOC_FFLUSH();
+            break;
+        }
+
+        // mask free bit out from the size, advance tail
+        _tail += slot_h->size & 0x7fffffffu;
+
+
+        // wrap around to start of ring
+        if (_tail == _buffer_end)
+        {
+            CC_DTRACE_ALLOC_PRINTF("    [free]     jumped from header [%u] to %u (wrap)\n", get_ptr_offset(slot_h), get_ptr_offset(_buffer_begin));
+            CC_DTRACE_ALLOC_FFLUSH();
+
+            _tail = _buffer_begin;
+        }
+        else
+        {
+            CC_DTRACE_ALLOC_PRINTF("    [free]     jumped from header [%u] to %u (non-wrap)\n", get_ptr_offset(slot_h), get_ptr_offset(_tail));
+            CC_DTRACE_ALLOC_FFLUSH();
+        }
+    }
+
+    if (_tail == _head)
+    {
+        CC_DTRACE_ALLOC_PRINTF("    [free]     tail == head\n");
+        CC_DTRACE_ALLOC_FFLUSH();
+    }
+}
+
+unsigned cc::scratch_allocator::get_ptr_offset(void const* ptr) const
+{
+    CC_ASSERT(ptr >= _buffer_begin && "programmer error");
+    return unsigned(static_cast<byte const*>(ptr) - _buffer_begin);
 }

--- a/src/clean-core/allocator.hh
+++ b/src/clean-core/allocator.hh
@@ -54,18 +54,6 @@ struct allocator : polymorphic
         void* ptr, size_t old_size, size_t new_min_size, size_t request_size, size_t& out_received_size, size_t align = alignof(std::max_align_t));
 };
 
-template <class T>
-[[nodiscard]] T align_up_masked(T value, size_t mask)
-{
-    return (T)(((size_t)value + mask) & ~mask);
-}
-
-/// increment the value (pointer or integer) to align at the given boundary
-template <class T>
-[[nodiscard]] T align_up(T value, size_t alignment)
-{
-    return align_up_masked(value, alignment - 1);
-}
 
 /// system provided allocator (malloc / free)
 struct system_allocator_t final : allocator
@@ -79,9 +67,11 @@ struct system_allocator_t final : allocator
     system_allocator_t() = default;
 };
 
+
 /// global instance of the system allocator (malloc / free) (thread safe)
 extern allocator* const system_allocator;
 extern system_allocator_t system_allocator_instance;
+
 
 /// trivial linear allocator operating in a given buffer
 /// cannot free individual allocations, only reset entirely
@@ -110,6 +100,7 @@ private:
     byte* _head = nullptr;
     byte* _buffer_end = nullptr;
 };
+
 
 /// stack allocator operating in a given buffer
 /// like a linear allocator, but can also free the most recent allocation

--- a/src/clean-core/capped_array.hh
+++ b/src/clean-core/capped_array.hh
@@ -60,7 +60,7 @@ public:
     constexpr capped_array(std::initializer_list<T> data)
     {
         CC_CONTRACT(data.size() <= N);
-        _size = data.size();
+        _size = compact_size_t(data.size());
         for (compact_size_t i = 0; i < _size; ++i)
             new (placement_new, &_u.value[i]) T(data.begin()[i]);
     }

--- a/src/clean-core/utility.hh
+++ b/src/clean-core/utility.hh
@@ -56,6 +56,20 @@ template <class T>
     return pos == 0 ? max - 1 : pos - 1;
 }
 
+/// Divide ints and round up, nom > 0, denom > 0
+template <class T>
+[[nodiscard]] constexpr T int_div_ceil(T nom, T denom)
+{
+    return 1 + ((nom - 1) / denom);
+}
+
+/// Ceil a value to a multiple of a given value
+template <class T>
+[[nodiscard]] constexpr T int_ceil_to_multiple(T val, T multiple)
+{
+    return ((val + multiple - 1) / multiple) * multiple;
+}
+
 [[maybe_unused]] struct
 {
     template <class T>
@@ -65,11 +79,4 @@ template <class T>
     }
 } constexpr swap; // implemented as functor so it cannot be found by ADL
 
-// Divide ints and round up
-// a > 0, b > 0
-template <class T>
-[[nodiscard]] constexpr T int_div_ceil(T a, T b)
-{
-    return 1 + ((a - 1) / b);
-}
 }


### PR DESCRIPTION
- Add `cc::scratch_allocator`, a ring-buffered allocator for temporary allocations with an optional fallback if overcommitted. This could serve as a generic (per-thread) scratch allocator, system-wide.
- Add `int_ceil_to_multiple` to utility.hh
- Fix a warning in capped_array