### PR TITLE
allow deref in range_ref and made it SFINAE friendly

### DIFF
--- a/src/clean-core/collection_traits.hh
+++ b/src/clean-core/collection_traits.hh
@@ -9,6 +9,10 @@
 #include <clean-core/move.hh>
 #include <clean-core/priority_tag.hh>
 
+// collection_traits<T> provide compile time information about how to use / call a collection
+// the cc::collection_xyz functions are designed to provide collection trait functions in a SFINAE-friendly manner
+// e.g. "decltype(*cc::collection_begin(some_range))" can be used in cc::enable_if or in decltype-SFINAE
+
 namespace cc
 {
 /**
@@ -36,28 +40,35 @@ struct collection_traits;
 //  - is_contiguous_range
 //  - is_any_contiguous_range
 
+/// returns the begin iterator for the collection
+/// NOTE: is SFINAE-friendly
 template <class CollectionT, cc::enable_if<collection_traits<CollectionT>::is_range> = true>
 constexpr decltype(auto) collection_begin(CollectionT&& c)
 {
-    static_assert(collection_traits<CollectionT>::is_range);
     return collection_traits<CollectionT>::begin(c);
 }
+
+/// returns the end iterator for the collection
+/// NOTE: is SFINAE-friendly
 template <class CollectionT, cc::enable_if<collection_traits<CollectionT>::is_range> = true>
 constexpr decltype(auto) collection_end(CollectionT&& c)
 {
-    static_assert(collection_traits<CollectionT>::is_range);
     return collection_traits<CollectionT>::end(c);
 }
+
+/// returns the size of a collection
+/// NOTE: is SFINAE-friendly
 template <class CollectionT, cc::enable_if<collection_traits<CollectionT>::has_size> = true>
 constexpr decltype(auto) collection_size(CollectionT&& c)
 {
-    static_assert(collection_traits<CollectionT>::has_size);
     return collection_traits<CollectionT>::size(c);
 }
+
+/// adds an element in a collection-defined semantic
+/// NOTE: is SFINAE-friendly
 template <class CollectionT, class T, cc::enable_if<collection_traits<CollectionT>::can_add> = true>
 constexpr decltype(auto) collection_add(CollectionT&& c, T&& value)
 {
-    static_assert(collection_traits<CollectionT>::can_add);
     return collection_traits<CollectionT>::add(c, cc::forward<T>(value));
 }
 

--- a/src/clean-core/collection_traits.hh
+++ b/src/clean-core/collection_traits.hh
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <type_traits>
 
+#include <clean-core/enable_if.hh>
 #include <clean-core/forward.hh>
 #include <clean-core/fwd.hh>
 #include <clean-core/move.hh>
@@ -35,25 +36,25 @@ struct collection_traits;
 //  - is_contiguous_range
 //  - is_any_contiguous_range
 
-template <class CollectionT>
+template <class CollectionT, cc::enable_if<collection_traits<CollectionT>::is_range> = true>
 constexpr decltype(auto) collection_begin(CollectionT&& c)
 {
     static_assert(collection_traits<CollectionT>::is_range);
     return collection_traits<CollectionT>::begin(c);
 }
-template <class CollectionT>
+template <class CollectionT, cc::enable_if<collection_traits<CollectionT>::is_range> = true>
 constexpr decltype(auto) collection_end(CollectionT&& c)
 {
     static_assert(collection_traits<CollectionT>::is_range);
     return collection_traits<CollectionT>::end(c);
 }
-template <class CollectionT>
+template <class CollectionT, cc::enable_if<collection_traits<CollectionT>::has_size> = true>
 constexpr decltype(auto) collection_size(CollectionT&& c)
 {
     static_assert(collection_traits<CollectionT>::has_size);
     return collection_traits<CollectionT>::size(c);
 }
-template <class CollectionT, class T>
+template <class CollectionT, class T, cc::enable_if<collection_traits<CollectionT>::can_add> = true>
 constexpr decltype(auto) collection_add(CollectionT&& c, T&& value)
 {
     static_assert(collection_traits<CollectionT>::can_add);
@@ -238,7 +239,14 @@ struct cc_array_collection_traits : base_collection_traits
 }
 
 template <class T, class>
-struct collection_traits : detail::inferred_collection_traits<T>
+struct collection_traits : detail::base_collection_traits // not a range
+{
+};
+
+// specialization for normal range-based for
+template <class RangeT>
+struct collection_traits<RangeT, std::void_t<decltype(std::declval<RangeT>().begin()), decltype(std::declval<RangeT>().end())>>
+  : detail::inferred_collection_traits<RangeT>
 {
 };
 

--- a/src/clean-core/range_ref.hh
+++ b/src/clean-core/range_ref.hh
@@ -15,6 +15,7 @@ namespace cc
 ///       this is designed to be mainly used as function argument (similar to span, string_view, stream_ref, etc.)
 ///
 /// TODO: expose function<void(function<void(T)>)> interface
+/// TODO: disambiguate case where element and *element are convertible to T
 template <class T>
 struct range_ref
 {
@@ -27,10 +28,9 @@ struct range_ref
     /// create a range_ref from any range (Range must support range-based-for)
     /// NOTE: range element types must be convertible to T
     /// CAUTION: range must always outlive the range_ref!
-    template <class Range, cc::enable_if<cc::is_any_range<Range>> = true>
+    template <class Range, cc::enable_if<std::is_convertible_v<decltype(*cc::collection_begin(std::declval<Range>())), T>> = true>
     range_ref(Range&& range)
     {
-        static_assert(std::is_convertible_v<decltype(*cc::collection_begin(range)), T>, "range elements must be convertible to T");
         if constexpr (std::is_const_v<std::remove_reference_t<Range>>)
         {
             _range.obj_const = &range;
@@ -48,14 +48,45 @@ struct range_ref
             };
         }
     }
+    template <class Range, cc::enable_if<std::is_convertible_v<decltype(**cc::collection_begin(std::declval<Range>())), T>> = true>
+    range_ref(Range&& range)
+    {
+        if constexpr (std::is_const_v<std::remove_reference_t<Range>>)
+        {
+            _range.obj_const = &range;
+            _for_each = [](storage const& s, cc::function_ref<void(T)> f) {
+                for (auto&& v : *static_cast<decltype(&range)>(s.obj_const))
+                    f(*v);
+            };
+        }
+        else
+        {
+            _range.obj = &range;
+            _for_each = [](storage const& s, cc::function_ref<void(T)> f) {
+                for (auto&& v : *static_cast<decltype(&range)>(s.obj))
+                    f(*v);
+            };
+        }
+    }
 
     /// creates a range_ref based on fixed values
-    range_ref(std::initializer_list<T> const& range)
+    template <class U, cc::enable_if<std::is_convertible_v<U const&, T>> = true>
+    range_ref(std::initializer_list<U> const& range)
     {
         _range.obj_const = &range;
         _for_each = [](storage const& s, cc::function_ref<void(T)> f) {
             for (auto&& v : *static_cast<decltype(&range)>(s.obj_const))
                 f(v);
+        };
+    }
+    /// creates a range_ref based on fixed values
+    template <class U, cc::enable_if<std::is_convertible_v<decltype(*std::declval<U const&>()), T>> = true>
+    range_ref(std::initializer_list<U> const& range)
+    {
+        _range.obj_const = &range;
+        _for_each = [](storage const& s, cc::function_ref<void(T)> f) {
+            for (auto&& v : *static_cast<decltype(&range)>(s.obj_const))
+                f(*v);
         };
     }
 

--- a/src/clean-core/range_ref.hh
+++ b/src/clean-core/range_ref.hh
@@ -16,6 +16,11 @@ namespace cc
 ///
 /// TODO: expose function<void(function<void(T)>)> interface
 /// TODO: disambiguate case where element and *element are convertible to T
+///
+/// Implementation note:
+///   the templated constructors use the SFINAE-friendly cc::collection_begin
+///   and are themselves designed to support SFINAE.
+///   this is important so that functions can be overloaded on different types of range_ref<T>s
 template <class T>
 struct range_ref
 {

--- a/src/clean-core/range_ref.hh
+++ b/src/clean-core/range_ref.hh
@@ -22,7 +22,7 @@ struct range_ref
     /// empty range
     range_ref()
     {
-        _for_each = [](cc::function_ref<void(T)>) {};
+        _for_each = [](storage const&, cc::function_ref<void(T)>) {};
     }
 
     /// create a range_ref from any range (Range must support range-based-for)


### PR DESCRIPTION
the deref feature allows transparent handling of pointer and smart pointer ranges.
e.g.:

```
void test(range_ref<foo const&> foos);
```
would be hard to call if the `foo` are managed in e.g. a `cc::vector<cc::poly_unique_ptr<foo>>`