### PR TITLE
Minor Changes

### DIFF
--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -69,7 +69,9 @@ public:
     size_t size() const { return _size; }
     size_t size_bytes() const { return _size * sizeof(T); }
     size_t capacity() const { return _capacity; }
+    size_t capacity_remaining() const { return _capacity - _size; }
     bool empty() const { return _size == 0; }
+    bool at_capacity() const { return capacity_remaining() == 0; }
     T* data() { return _data; }
     T const* data() const { return _data; }
     T* begin() { return _data; }

--- a/src/clean-core/macros.hh
+++ b/src/clean-core/macros.hh
@@ -59,7 +59,6 @@
 #define CC_HOT_FUNC
 
 #define CC_BUILTIN_UNREACHABLE __assume(0)
-#define CC_PRINTF_FUNC(_fmt_index_, _args_index_)
 
 #elif defined(CC_COMPILER_POSIX)
 
@@ -75,14 +74,27 @@
 #define CC_HOT_FUNC __attribute__((hot))
 
 #define CC_BUILTIN_UNREACHABLE __builtin_unreachable()
-// enables warnings/errors on malformed calls to a printf-like function
-// indices start at 1 and count the implicit 'this'-argument of methods
-#define CC_PRINTF_FUNC(_fmt_index_, _args_index_) __attribute__((format(printf, _fmt_index_, _args_index_)))
 
 #else
 #error "Unknown compiler"
 #endif
 
+// =========
+// compiler/code model helpers
+
+#if defined(CC_COMPILER_POSIX) || defined(__clang__) || defined(__GNUC__)
+// even if code isn't compiled on a POSIX compiler, these helpers can still
+// be active in ie. a clang code model (ie.: MSVC via Qt Creator)
+
+// enables warnings/errors on malformed calls to a printf-like function
+// indices start at 1 and count the implicit 'this'-argument of methods
+#define CC_PRINTF_FUNC(_fmt_index_) __attribute__((format(printf, _fmt_index_, _fmt_index_ + 1)))
+
+#else
+
+#define CC_PRINTF_FUNC(_fmt_index_)
+
+#endif
 
 // =========
 // common helper

--- a/src/clean-core/macros.hh
+++ b/src/clean-core/macros.hh
@@ -1,10 +1,7 @@
 #pragma once
 
-// TODO: use [[likely]] and [[unlikely]] in C++20
-
-
 // =========
-// configurations
+// compiler
 
 #if defined(_MSC_VER)
 #define CC_COMPILER_MSVC
@@ -55,6 +52,7 @@
 #define CC_FORCE_INLINE __forceinline
 #define CC_DONT_INLINE __declspec(noinline)
 
+// only way of reproducing these is using C++20 [[likely]] / [[unlikely]]
 #define CC_LIKELY(x) x
 #define CC_UNLIKELY(x) x
 #define CC_COLD_FUNC
@@ -67,6 +65,7 @@
 
 #define CC_PRETTY_FUNC __PRETTY_FUNCTION__
 
+// additional 'inline' is required on gcc and makes no difference on clang
 #define CC_FORCE_INLINE __attribute__((always_inline)) inline
 #define CC_DONT_INLINE __attribute__((noinline))
 
@@ -76,6 +75,8 @@
 #define CC_HOT_FUNC __attribute__((hot))
 
 #define CC_BUILTIN_UNREACHABLE __builtin_unreachable()
+// enables warnings/errors on malformed calls to a printf-like function
+// indices start at 1 and count the implicit 'this'-argument of methods
 #define CC_PRINTF_FUNC(_fmt_index_, _args_index_) __attribute__((format(printf, _fmt_index_, _args_index_)))
 
 #else


### PR DESCRIPTION
- Add `vector::capacity_remaining` and `at_capacity`
- Simplify `CC_PRINTF_FUNC` macro to just take a single index
    - enable `CC_PRINTF_FUNC` to work with supporting code models regardless of the compiler