### PR TITLE
intrinsics.hh, minor changes

### DIFF
--- a/cmake/SourceGroup.cmake
+++ b/cmake/SourceGroup.cmake
@@ -11,7 +11,7 @@
 macro(arcana_source_group)
     foreach(loop_var ${ARGN})
 
-        if (${CMAKE_GENERATOR} MATCHES "Visual Studio")
+        if (${CMAKE_GENERATOR} MATCHES "Visual Studio" OR WIN32)
             source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/src" FILES ${${loop_var}})
         else()
             source_group("${CMAKE_CURRENT_SOURCE_DIR}/src" FILES ${${loop_var}})

--- a/src/clean-core/alloc_vector.hh
+++ b/src/clean-core/alloc_vector.hh
@@ -116,6 +116,8 @@ public:
         this->_allocator = new_allocator;
         this->reserve(reserve_size);
     }
+
+    cc::allocator* allocator() const { return this->_allocator; }
 };
 
 // hash

--- a/src/clean-core/bits.hh
+++ b/src/clean-core/bits.hh
@@ -87,13 +87,6 @@ inline int count_leading_zeros(uint64 v)
 }
 #endif
 
-inline bool test_cpuid_register(int level, int register_index, int bit_index)
-{
-    int info[4];
-    __cpuid(info, level);
-    return (info[register_index] >> bit_index) != 0;
-}
-
 #else
 
 inline int popcount(uint8 v) { return __builtin_popcount(v); }
@@ -126,19 +119,7 @@ inline int count_leading_zeros(uint32 v) { return v ? __builtin_clz(v) : 32; }
 inline int count_leading_zeros(uint64 v) { return v ? __builtin_clzll(v) : 64; }
 #endif
 
-inline bool test_cpuid_register(int level, int register_index, int bit_index)
-{
-    unsigned info[4];
-    __get_cpuid(level, &info[0], &info[1], &info[2], &info[3]);
-    return (info[register_index] >> bit_index) != 0;
-}
 #endif
-
-// returns true if the executing CPU has support for LZCNT
-// Intel: Haswell (4th gen Core-i, 2013), AMD: Piledriver (ABM, 2012)
-inline bool test_cpu_support_lzcnt() { return test_cpuid_register(0x80000001, 2, 5); }
-// returns true if the executing CPU has support for POPCNT
-inline bool test_cpu_support_popcount() { return test_cpuid_register(0x00000001, 2, 23); }
 
 // returns rounded down logarithm to base 2
 inline uint32 bit_log2(uint32 v) { return uint32(8 * sizeof(uint32) - count_leading_zeros(v) - 1); }

--- a/src/clean-core/intrinsics.hh
+++ b/src/clean-core/intrinsics.hh
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cstdint>
+
+#include <clean-core/macros.hh>
+
+#ifdef CC_COMPILER_MSVC
+#include <intrin.h>
+#else
+#include <cpuid.h>
+#include <x86intrin.h>
+#endif
+
+namespace cc
+{
+CC_FORCE_INLINE uint64_t intrin_rdtsc()
+{
+#ifdef CC_COMPILER_GCC
+    unsigned int lo, hi;
+    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+    return ((uint64_t)hi << 32) | lo;
+#else // Clang, MSVC
+    return __rdtsc();
+#endif
+}
+
+CC_FORCE_INLINE uint32_t intrin_cas(uint32_t volatile* dst, uint32_t cmp, uint32_t exc)
+{
+#ifdef CC_COMPILER_MSVC
+    return _InterlockedCompareExchange((volatile long*)dst, exc, cmp);
+#else
+    return __sync_val_compare_and_swap(dst, cmp, exc);
+#endif
+}
+
+CC_FORCE_INLINE uint64_t intrin_cas(uint64_t volatile* dst, uint64_t cmp, uint64_t exc)
+{
+#ifdef CC_COMPILER_MSVC
+    return _InterlockedCompareExchange64((volatile long long*)dst, exc, cmp);
+#else
+    return __sync_val_compare_and_swap(dst, cmp, exc);
+#endif
+}
+
+CC_FORCE_INLINE int32_t intrin_atomic_add(int32_t volatile* counter, int32_t value)
+{
+#ifdef CC_COMPILER_MSVC
+    return _InterlockedExchangeAdd((volatile long*)counter, value);
+#else
+    return __sync_fetch_and_add(counter, value);
+#endif
+}
+
+CC_FORCE_INLINE int64_t intrin_atomic_add(int64_t volatile* counter, int64_t value)
+{
+#ifdef CC_COMPILER_MSVC
+    return _InterlockedExchangeAdd64(counter, value);
+#else
+    return __sync_fetch_and_add(counter, value);
+#endif
+}
+
+inline bool test_cpuid_register(int level, int register_index, int bit_index)
+{
+#ifdef CC_COMPILER_MSVC
+    int info[4];
+    __cpuid(info, level);
+    return (info[register_index] >> bit_index) != 0;
+#else
+    unsigned info[4];
+    __get_cpuid(level, &info[0], &info[1], &info[2], &info[3]);
+    return (info[register_index] >> bit_index) != 0;
+#endif
+}
+
+// returns true if the executing CPU has support for LZCNT
+// Intel: Haswell (4th gen Core-i, 2013), AMD: Piledriver (ABM, 2012)
+inline bool test_cpu_support_lzcnt() { return test_cpuid_register(0x80000001, 2, 5); }
+
+// returns true if the executing CPU has support for POPCNT
+inline bool test_cpu_support_popcount() { return test_cpuid_register(0x00000001, 2, 23); }
+
+
+}

--- a/src/clean-core/macros.hh
+++ b/src/clean-core/macros.hh
@@ -59,6 +59,7 @@
 #define CC_HOT_FUNC
 
 #define CC_BUILTIN_UNREACHABLE __assume(0)
+#define CC_COUNTOF(arr) _countof(arr)
 
 #elif defined(CC_COMPILER_POSIX)
 
@@ -74,6 +75,7 @@
 #define CC_HOT_FUNC __attribute__((hot))
 
 #define CC_BUILTIN_UNREACHABLE __builtin_unreachable()
+#define CC_COUNTOF(arr) (sizeof(arr) / sizeof(arr[0]))
 
 #else
 #error "Unknown compiler"


### PR DESCRIPTION
- added `intrinsics.hh`
    - `intrin_rdtsc`, `intrin_cas`, `intrin_atomic_add`
    - moved cpuid testing helpers from `bits.hh`
    - this header also allows dropping ctracer as a nexus dependency
- minor changes
    - fixed arcana_source_group for win32 Qt Creator