### PR TITLE
Threadsafe allocators, stack trace printing, DLL option in AddLibrary.cmake

### DIFF
--- a/cmake/AddLibrary.cmake
+++ b/cmake/AddLibrary.cmake
@@ -18,6 +18,7 @@ function(arcana_add_library LIB_PREFIX LIB_TARGET SOURCES_VARIABLE_NAME HEADERS_
     arcana_source_group(${SOURCES_VARIABLE_NAME} ${HEADERS_VARIABLE_NAME})
 
     option(${LIB_PREFIX}_ENABLE_UNITY_BUILD "If enabled, compiles this library as a single compilation unit" ON)
+    option(${LIB_PREFIX}_BUILD_DLL "If enabled, build a shared DLL instead of a static library" OFF)
 
     if (${${LIB_PREFIX}_ENABLE_UNITY_BUILD})
         if (CC_VERBOSE_CMAKE)
@@ -26,7 +27,21 @@ function(arcana_add_library LIB_PREFIX LIB_TARGET SOURCES_VARIABLE_NAME HEADERS_
         arcana_enable_unity_build(${LIB_TARGET} ${SOURCES_VARIABLE_NAME} 100 cc)
     endif()
 
-    add_library(${LIB_TARGET} STATIC ${${SOURCES_VARIABLE_NAME}} ${${HEADERS_VARIABLE_NAME}})
+    if (${${LIB_PREFIX}_BUILD_DLL})
+        if (CC_VERBOSE_CMAKE)
+            message(STATUS "[${LIB_TARGET}] building shared library (DLL)")
+        endif()
+
+        add_library(${LIB_TARGET} SHARED ${${SOURCES_VARIABLE_NAME}} ${${HEADERS_VARIABLE_NAME}})
+        # define <LIB>_BUILD_DLL always, and <LIB>_DLL only privately - when the DLL itself is being built
+        # macro is used to differentiate between dllexport/dllimport
+        target_compile_definitions(${LIB_TARGET} PUBLIC ${LIB_PREFIX}_BUILD_DLL PRIVATE ${LIB_PREFIX}_DLL)
+    else()
+        if (CC_VERBOSE_CMAKE)
+            message(STATUS "[${LIB_TARGET}] building static library")
+        endif()
+        add_library(${LIB_TARGET} STATIC ${${SOURCES_VARIABLE_NAME}} ${${HEADERS_VARIABLE_NAME}})
+    endif()
 
     arcana_configure_lib_options(${LIB_TARGET})
 

--- a/src/clean-core/alloc_array.hh
+++ b/src/clean-core/alloc_array.hh
@@ -180,6 +180,8 @@ struct alloc_array
         return false;
     }
 
+    cc::allocator* allocator() const { return this->_allocator; }
+
 private:
     T* _alloc(size_t size) { return reinterpret_cast<T*>(_allocator->alloc(size * sizeof(T), alignof(T))); }
     void _free(T* p) { _allocator->free(p); }

--- a/src/clean-core/allocator.cc
+++ b/src/clean-core/allocator.cc
@@ -41,17 +41,7 @@ std::byte* align_up_with_header(std::byte* head, size_t align, size_t header_siz
 }
 }
 
-cc::byte* cc::linear_allocator::alloc(cc::size_t size, cc::size_t align)
-{
-    CC_ASSERT(_buffer_begin != nullptr && "linear_allocator uninitialized");
 
-    auto* const padded_res = align_up(_head, align);
-
-    CC_ASSERT(padded_res + size <= _buffer_end && "linear_allocator overcommitted");
-
-    _head = padded_res + size;
-    return padded_res;
-}
 
 cc::byte* cc::stack_allocator::alloc(cc::size_t size, cc::size_t align)
 {

--- a/src/clean-core/allocator.cc
+++ b/src/clean-core/allocator.cc
@@ -9,32 +9,12 @@
 #include <clean-core/string_view.hh>
 #include <clean-core/utility.hh>
 
-// enable debug trace prints in some allocators
-#define CC_ENABLE_DTRACE_ALLOC 0
-
-#if CC_ENABLE_DTRACE_ALLOC
-#define CC_DTRACE_ALLOC_PRINTF printf
-#define CC_DTRACE_ALLOC_FFLUSH() fflush(stdout)
-#else
-#define CC_DTRACE_ALLOC_PRINTF(...) (void)0
-#define CC_DTRACE_ALLOC_FFLUSH() (void)0
-#endif
-
-
 namespace
 {
 struct stack_alloc_header
 {
     size_t padding;
 };
-
-struct scratch_alloc_header
-{
-    uint32_t size;
-};
-
-constexpr uint32_t const gc_header_pad_value = 0xffffffffu;
-constexpr uint32_t const gc_header_free_bit = 0x80000000u;
 
 // [... pad ...] [header] [data]
 std::byte* align_up_with_header(std::byte* head, size_t align, size_t header_size)
@@ -58,31 +38,6 @@ std::byte* align_up_with_header(std::byte* head, size_t align, size_t header_siz
     }
 
     return padded_res;
-}
-
-// [header] [... pad ...] [data]
-std::byte* align_up_from_header(scratch_alloc_header* header, size_t align)
-{
-    void* const p = header + 1;
-    return static_cast<std::byte*>(cc::align_up(p, align));
-}
-
-// returns a pointer to the header preceding the given allocation
-scratch_alloc_header* get_header_before_pointer(void* ptr)
-{
-    uint32_t* p = (uint32_t*)ptr;
-    while (p[-1] == gc_header_pad_value)
-        --p;
-    return (scratch_alloc_header*)p - 1;
-}
-
-// writes the size of an allocation to a header, and 0xFF to the bytes between the header and the allocation
-void fill_in_header_value(scratch_alloc_header* header, void* associated_data_ptr, uint32_t size)
-{
-    header->size = size;
-    uint32_t* p = (uint32_t*)(header + 1);
-    while (p < associated_data_ptr)
-        *p++ = gc_header_pad_value;
 }
 }
 
@@ -240,142 +195,4 @@ cc::byte* cc::allocator::realloc_request(void* ptr, cc::size_t old_size, cc::siz
     CC_UNUSED(request_size);
     out_received_size = new_min_size;
     return this->realloc(ptr, old_size, new_min_size, align);
-}
-
-/*
- * cc::scratch_allocator is based on the bitsquid foundation ScratchAllocator
- * https://github.com/niklas-ourmachinery/bitsquid-foundation/blob/master/memory.cpp#L142
- * the original implementation contains bugs which are fixed here
- *
- * original license (MIT):
- *
- * Copyright (C) 2012 Bitsquid AB
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-
-cc::byte* cc::scratch_allocator::alloc(cc::size_t size, cc::size_t align)
-{
-    CC_DTRACE_ALLOC_PRINTF("    [alloc]    call - size %zu, align %zu\n", size, align);
-
-    size = int_ceil_to_multiple<size_t>(size, 4);
-
-    byte* p = _head;
-    scratch_alloc_header* h = reinterpret_cast<scratch_alloc_header*>(p);
-    byte* data = align_up_from_header(h, align); // points to after the header, aligned
-    p = data + size;                             // end of planned allocation
-
-    // end would be OOB, wrap around to start of ring
-    if (p > _buffer_end)
-    {
-        // write wraparound marker to the header
-        CC_ASSERT(reinterpret_cast<byte*>(h) < _buffer_end && "programmer error");
-        uint32_t const num_bytes_until_end = uint32_t(_buffer_end - reinterpret_cast<byte*>(h));
-
-        CC_DTRACE_ALLOC_PRINTF("    [alloc]    %zu bytes would wrap, writing %u to wraparound header [%u]\n", size, num_bytes_until_end, get_ptr_offset(h));
-
-        h->size = (num_bytes_until_end | gc_header_free_bit);
-
-        p = _buffer_begin;
-        h = reinterpret_cast<scratch_alloc_header*>(p);
-        data = align_up_from_header(h, align); // points to after the header, aligned
-        p = data + size;                       // end of planned allocation
-    }
-
-    if (p > _buffer_end || in_use(p))
-    {
-        // ring buffer is exhausted, use fallback
-        CC_ASSERT(_backing_alloc != nullptr && "scratch_allocator out of memory and no backing allocator present");
-        return _backing_alloc->alloc(size, align);
-    }
-
-    // write size to the header
-    uint32 const allocsize = static_cast<uint32>(p - reinterpret_cast<byte*>(h));
-    fill_in_header_value(h, data, allocsize);
-    _head = p;
-
-    if (_head == _buffer_end)
-    {
-        // head is at end of the buffer, and would never be reached by the free loop, wrap to begin
-        _head = _buffer_begin;
-    }
-
-    CC_DTRACE_ALLOC_PRINTF("    [alloc]    head: %u, writing %u to header [%u]\n", get_ptr_offset(_head), allocsize, get_ptr_offset(h));
-    CC_DTRACE_ALLOC_FFLUSH();
-
-
-    return data;
-}
-
-void cc::scratch_allocator::free(void* ptr)
-{
-    if (ptr == nullptr)
-        return;
-
-
-    // free from backing allocator if not in own ring buffer
-    if (ptr < _buffer_begin || ptr > _buffer_end)
-    {
-        CC_ASSERT(_backing_alloc != nullptr && "freed out of bounds pointer with scratch allocator and no backing allocator present that could be the source of it");
-        _backing_alloc->free(ptr);
-        return;
-    }
-
-    // mark header of freed slot as free
-    scratch_alloc_header* const h = get_header_before_pointer(ptr);
-
-    CC_DTRACE_ALLOC_PRINTF("    [free]     freeing %u, entering loop (tail: %u, head: %u)\n", get_ptr_offset(h), get_ptr_offset(_tail), get_ptr_offset(_head));
-
-    CC_ASSERT((h->size & gc_header_free_bit) == 0 && "scratch_allocator double free");
-    h->size = h->size | gc_header_free_bit;
-
-
-    // advance tail past all free slots
-    while (_tail != _head)
-    {
-        scratch_alloc_header const* const slot_h = reinterpret_cast<scratch_alloc_header*>(_tail);
-
-        // break once a non-free slot was reached
-        if ((slot_h->size & gc_header_free_bit) == 0)
-        {
-            CC_DTRACE_ALLOC_PRINTF("    [free]     reached non-free header [%u] (break)\n", get_ptr_offset(slot_h));
-            CC_DTRACE_ALLOC_FFLUSH();
-            break;
-        }
-
-        // mask free bit out from the size, advance tail
-        _tail += slot_h->size & 0x7fffffffu;
-
-
-        // wrap around to start of ring
-        if (_tail == _buffer_end)
-        {
-            CC_DTRACE_ALLOC_PRINTF("    [free]     jumped from header [%u] to %u (wrap)\n", get_ptr_offset(slot_h), get_ptr_offset(_buffer_begin));
-            CC_DTRACE_ALLOC_FFLUSH();
-
-            _tail = _buffer_begin;
-        }
-        else
-        {
-            CC_DTRACE_ALLOC_PRINTF("    [free]     jumped from header [%u] to %u (non-wrap)\n", get_ptr_offset(slot_h), get_ptr_offset(_tail));
-            CC_DTRACE_ALLOC_FFLUSH();
-        }
-    }
-
-    if (_tail == _head)
-    {
-        CC_DTRACE_ALLOC_PRINTF("    [free]     tail == head\n");
-        CC_DTRACE_ALLOC_FFLUSH();
-    }
-}
-
-unsigned cc::scratch_allocator::get_ptr_offset(void const* ptr) const
-{
-    CC_ASSERT(ptr >= _buffer_begin && "programmer error");
-    return unsigned(static_cast<byte const*>(ptr) - _buffer_begin);
 }

--- a/src/clean-core/allocator.hh
+++ b/src/clean-core/allocator.hh
@@ -3,13 +3,12 @@
 #include <clean-core/forward.hh>
 #include <clean-core/fwd.hh>
 #include <clean-core/new.hh>
-#include <clean-core/polymorphic.hh>
 #include <clean-core/span.hh>
 #include <clean-core/typedefs.hh>
 
 namespace cc
 {
-struct allocator : polymorphic
+struct allocator
 {
     /// allocate a buffer with specified size and alignment
     [[nodiscard]] virtual byte* alloc(size_t size, size_t align = alignof(std::max_align_t)) = 0;
@@ -59,6 +58,14 @@ struct allocator : polymorphic
     /// reallocate a buffer with specified minimum size, will span up to request_size if possible
     [[nodiscard]] virtual byte* realloc_request(
         void* ptr, size_t old_size, size_t new_min_size, size_t request_size, size_t& out_received_size, size_t align = alignof(std::max_align_t));
+
+    // delete copy, default move
+    allocator() = default;
+    allocator(allocator const&) = delete;
+    allocator& operator=(allocator const&) = delete;
+    allocator(allocator&&) noexcept = default;
+    allocator& operator=(allocator&&) noexcept = default;
+    virtual ~allocator() = default;
 };
 
 
@@ -193,8 +200,6 @@ struct tlsf_allocator final : allocator
 
     std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t)) override;
 
-    tlsf_allocator(tlsf_allocator const&) = delete;
-    tlsf_allocator& operator==(tlsf_allocator const&) = delete;
     tlsf_allocator(tlsf_allocator&& rhs) noexcept : _tlsf(rhs._tlsf) { rhs._tlsf = nullptr; }
     tlsf_allocator& operator==(tlsf_allocator&& rhs) noexcept
     {

--- a/src/clean-core/allocator.hh
+++ b/src/clean-core/allocator.hh
@@ -172,6 +172,39 @@ private:
     allocator* _backing_alloc = nullptr;
 };
 
+/// Two Level Segregated Fit allocator
+/// O(1) cost for alloc, free, realloc
+/// extremely low memory overhead, 4 byte per allocation
+struct tlsf_allocator final : allocator
+{
+    tlsf_allocator() = default;
+    tlsf_allocator(cc::span<std::byte> buffer) { initialize(buffer); }
+    ~tlsf_allocator() { destroy(); }
+
+    void initialize(cc::span<std::byte> buffer);
+    void destroy();
+
+    std::byte* alloc(size_t size, size_t align = alignof(std::max_align_t)) override;
+
+    void free(void* ptr) override;
+
+    std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t)) override;
+
+    tlsf_allocator(tlsf_allocator const&) = delete;
+    tlsf_allocator& operator==(tlsf_allocator const&) = delete;
+    tlsf_allocator(tlsf_allocator&& rhs) noexcept : _tlsf(rhs._tlsf) { rhs._tlsf = nullptr; }
+    tlsf_allocator& operator==(tlsf_allocator&& rhs) noexcept
+    {
+        destroy();
+        _tlsf = rhs._tlsf;
+        rhs._tlsf = nullptr;
+        return *this;
+    }
+
+private:
+    void* _tlsf = nullptr;
+};
+
 //
 // templated virtual allocator interface implementation below
 

--- a/src/clean-core/allocator.scratch.cc
+++ b/src/clean-core/allocator.scratch.cc
@@ -1,0 +1,195 @@
+#include <clean-core/allocator.hh>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+#include <clean-core/assert.hh>
+#include <clean-core/utility.hh>
+
+// enable debug trace prints in some allocators
+#define CC_ENABLE_DTRACE_ALLOC 0
+
+#if CC_ENABLE_DTRACE_ALLOC
+#define CC_DTRACE_ALLOC_PRINTF printf
+#define CC_DTRACE_ALLOC_FFLUSH() fflush(stdout)
+#else
+#define CC_DTRACE_ALLOC_PRINTF(...) (void)0
+#define CC_DTRACE_ALLOC_FFLUSH() (void)0
+#endif
+
+
+namespace
+{
+struct scratch_alloc_header
+{
+    uint32_t size;
+};
+
+constexpr uint32_t const gc_header_pad_value = 0xffffffffu;
+constexpr uint32_t const gc_header_free_bit = 0x80000000u;
+
+// [header] [... pad ...] [data]
+std::byte* align_up_from_header(scratch_alloc_header* header, size_t align)
+{
+    void* const p = header + 1;
+    return static_cast<std::byte*>(cc::align_up(p, align));
+}
+
+// returns a pointer to the header preceding the given allocation
+scratch_alloc_header* get_header_before_pointer(void* ptr)
+{
+    uint32_t* p = (uint32_t*)ptr;
+    while (p[-1] == gc_header_pad_value)
+        --p;
+    return (scratch_alloc_header*)p - 1;
+}
+
+// writes the size of an allocation to a header, and 0xFF to the bytes between the header and the allocation
+void fill_in_header_value(scratch_alloc_header* header, void* associated_data_ptr, uint32_t size)
+{
+    header->size = size;
+    uint32_t* p = (uint32_t*)(header + 1);
+    while (p < associated_data_ptr)
+        *p++ = gc_header_pad_value;
+}
+}
+
+
+/*
+ * cc::scratch_allocator is based on the bitsquid foundation ScratchAllocator
+ * https://github.com/niklas-ourmachinery/bitsquid-foundation/blob/master/memory.cpp#L142
+ * the original implementation contains bugs which are fixed here
+ *
+ * original license (MIT):
+ *
+ * Copyright (C) 2012 Bitsquid AB
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+cc::byte* cc::scratch_allocator::alloc(cc::size_t size, cc::size_t align)
+{
+    CC_DTRACE_ALLOC_PRINTF("    [alloc]    call - size %zu, align %zu\n", size, align);
+
+    size = int_ceil_to_multiple<size_t>(size, 4);
+
+    byte* p = _head;
+    scratch_alloc_header* h = reinterpret_cast<scratch_alloc_header*>(p);
+    byte* data = align_up_from_header(h, align); // points to after the header, aligned
+    p = data + size;                             // end of planned allocation
+
+    // end would be OOB, wrap around to start of ring
+    if (p > _buffer_end)
+    {
+        // write wraparound marker to the header
+        CC_ASSERT(reinterpret_cast<byte*>(h) < _buffer_end && "programmer error");
+        uint32_t const num_bytes_until_end = uint32_t(_buffer_end - reinterpret_cast<byte*>(h));
+
+        CC_DTRACE_ALLOC_PRINTF("    [alloc]    %zu bytes would wrap, writing %u to wraparound header [%u]\n", size, num_bytes_until_end, get_ptr_offset(h));
+
+        h->size = (num_bytes_until_end | gc_header_free_bit);
+
+        p = _buffer_begin;
+        h = reinterpret_cast<scratch_alloc_header*>(p);
+        data = align_up_from_header(h, align); // points to after the header, aligned
+        p = data + size;                       // end of planned allocation
+    }
+
+    if (p > _buffer_end || in_use(p))
+    {
+        // ring buffer is exhausted, use fallback
+        CC_ASSERT(_backing_alloc != nullptr && "scratch_allocator out of memory and no backing allocator present");
+        return _backing_alloc->alloc(size, align);
+    }
+
+    // write size to the header
+    uint32 const allocsize = static_cast<uint32>(p - reinterpret_cast<byte*>(h));
+    fill_in_header_value(h, data, allocsize);
+    _head = p;
+
+    if (_head == _buffer_end)
+    {
+        // head is at end of the buffer, and would never be reached by the free loop, wrap to begin
+        _head = _buffer_begin;
+    }
+
+    CC_DTRACE_ALLOC_PRINTF("    [alloc]    head: %u, writing %u to header [%u]\n", get_ptr_offset(_head), allocsize, get_ptr_offset(h));
+    CC_DTRACE_ALLOC_FFLUSH();
+
+
+    return data;
+}
+
+void cc::scratch_allocator::free(void* ptr)
+{
+    if (ptr == nullptr)
+        return;
+
+
+    // free from backing allocator if not in own ring buffer
+    if (ptr < _buffer_begin || ptr > _buffer_end)
+    {
+        CC_ASSERT(_backing_alloc != nullptr && "freed out of bounds pointer with scratch allocator and no backing allocator present that could be the source of it");
+        _backing_alloc->free(ptr);
+        return;
+    }
+
+    // mark header of freed slot as free
+    scratch_alloc_header* const h = get_header_before_pointer(ptr);
+
+    CC_DTRACE_ALLOC_PRINTF("    [free]     freeing %u, entering loop (tail: %u, head: %u)\n", get_ptr_offset(h), get_ptr_offset(_tail), get_ptr_offset(_head));
+
+    CC_ASSERT((h->size & gc_header_free_bit) == 0 && "scratch_allocator double free");
+    h->size = h->size | gc_header_free_bit;
+
+
+    // advance tail past all free slots
+    while (_tail != _head)
+    {
+        scratch_alloc_header const* const slot_h = reinterpret_cast<scratch_alloc_header*>(_tail);
+
+        // break once a non-free slot was reached
+        if ((slot_h->size & gc_header_free_bit) == 0)
+        {
+            CC_DTRACE_ALLOC_PRINTF("    [free]     reached non-free header [%u] (break)\n", get_ptr_offset(slot_h));
+            CC_DTRACE_ALLOC_FFLUSH();
+            break;
+        }
+
+        // mask free bit out from the size, advance tail
+        _tail += slot_h->size & 0x7fffffffu;
+
+
+        // wrap around to start of ring
+        if (_tail == _buffer_end)
+        {
+            CC_DTRACE_ALLOC_PRINTF("    [free]     jumped from header [%u] to %u (wrap)\n", get_ptr_offset(slot_h), get_ptr_offset(_buffer_begin));
+            CC_DTRACE_ALLOC_FFLUSH();
+
+            _tail = _buffer_begin;
+        }
+        else
+        {
+            CC_DTRACE_ALLOC_PRINTF("    [free]     jumped from header [%u] to %u (non-wrap)\n", get_ptr_offset(slot_h), get_ptr_offset(_tail));
+            CC_DTRACE_ALLOC_FFLUSH();
+        }
+    }
+
+    if (_tail == _head)
+    {
+        CC_DTRACE_ALLOC_PRINTF("    [free]     tail == head\n");
+        CC_DTRACE_ALLOC_FFLUSH();
+    }
+}
+
+unsigned cc::scratch_allocator::get_ptr_offset(void const* ptr) const
+{
+    CC_ASSERT(ptr >= _buffer_begin && "programmer error");
+    return unsigned(static_cast<byte const*>(ptr) - _buffer_begin);
+}

--- a/src/clean-core/allocator.tlsf.cc
+++ b/src/clean-core/allocator.tlsf.cc
@@ -1,0 +1,38 @@
+#include <clean-core/allocator.hh>
+
+#include <clean-core/detail/lib/tlsf.hh>
+
+std::byte* cc::tlsf_allocator::alloc(size_t size, size_t align)
+{
+    CC_ASSERT(size > 0 && "Attempted empty TLSF allocation");
+    auto const res = static_cast<std::byte*>(tlsf_memalign(_tlsf, align, size));
+    CC_ASSERT(res != nullptr && "TLSF full");
+    return res;
+}
+
+void cc::tlsf_allocator::free(void* ptr) { tlsf_free(_tlsf, ptr); }
+
+std::byte* cc::tlsf_allocator::realloc(void* ptr, size_t old_size, size_t new_size, size_t align)
+{
+    (void)old_size;
+    (void)align;
+    return static_cast<std::byte*>(tlsf_realloc(_tlsf, ptr, new_size));
+}
+
+void cc::tlsf_allocator::initialize(cc::span<std::byte> buffer)
+{
+    CC_ASSERT(_tlsf == nullptr && "double init");
+    CC_ASSERT(buffer.size() > tlsf_size() && "buffer not large enough");
+
+    _tlsf = tlsf_create_with_pool(buffer.data(), buffer.size());
+    CC_ASSERT(_tlsf != nullptr && "failed to creat TLSF");
+}
+
+void cc::tlsf_allocator::destroy()
+{
+    if (_tlsf)
+    {
+        tlsf_destroy(_tlsf);
+        _tlsf = nullptr;
+    }
+}

--- a/src/clean-core/atomic_linked_pool.hh
+++ b/src/clean-core/atomic_linked_pool.hh
@@ -30,20 +30,20 @@ struct atomic_linked_pool
 
     void initialize(size_t size, cc::allocator* allocator = cc::system_allocator)
     {
-        static_assert(sizeof(T) >= sizeof(T*), "linked_pool element type must be large enough to accomodate a pointer");
+        static_assert(sizeof(T) >= sizeof(T*), "atomic_linked_pool element type must be large enough to accomodate a pointer");
         if (size == 0)
             return;
 
         if constexpr (sc_enable_gen_check)
         {
-            CC_ASSERT(size < 1u << sc_num_index_bits && "linked_pool size too large for index type");
+            CC_ASSERT(size <= sc_max_size_with_gen_check && "atomic_linked_pool size too large for index type");
         }
         else
         {
-            CC_ASSERT(size < (1u << (32 - sc_num_padding_bits)) && "linked_pool size too large for index type");
+            CC_ASSERT(size <= sc_max_size_without_gen_check && "atomic_linked_pool size too large for index type");
         }
 
-        CC_ASSERT(_pool == nullptr && "re-initialized linked_pool");
+        CC_ASSERT(_pool == nullptr && "re-initialized atomic_linked_pool");
         CC_CONTRACT(allocator != nullptr);
 
         _alloc = allocator;
@@ -72,6 +72,16 @@ struct atomic_linked_pool
         }
 
         _first_free_node = &_pool[0];
+
+        if constexpr (!std::is_trivially_destructible_v<T>)
+        {
+            // set up the function pointer now, as T is complete in this function (unlike in the dtor and this->_destroy())
+            _fptr_call_all_dtors = +[](atomic_linked_pool& pool) { pool.iterate_allocated_nodes([](T& node) { node.~T(); }); };
+        }
+        else
+        {
+            _fptr_call_all_dtors = nullptr;
+        }
     }
 
     void destroy() { _destroy(); }
@@ -79,7 +89,7 @@ struct atomic_linked_pool
     /// acquire a new slot in the pool
     [[nodiscard]] handle_t acquire()
     {
-        CC_ASSERT(!is_full() && "linked_pool full");
+        CC_ASSERT(!is_full() && "atomic_linked_pool full");
 
         // CAS-loop to acquire a free node and write the matching next pointer
         bool cas_success = false;
@@ -155,7 +165,7 @@ struct atomic_linked_pool
     CC_FORCE_INLINE uint32_t get_node_index(T const* node) const
     {
         CC_ASSERT(node >= &_pool[0] && node < &_pool[_pool_size] && "node outside of pool");
-        return node - _pool;
+        return uint32_t(node - _pool);
     }
 
     /// obtain the index of a node
@@ -171,6 +181,8 @@ struct atomic_linked_pool
     template <class F>
     unsigned iterate_allocated_nodes(F&& func, cc::allocator* scratch_alloc = cc::system_allocator)
     {
+        static_assert(sizeof(T) > 0, "requires complete type");
+
         if (_pool == nullptr)
             return 0;
 
@@ -207,6 +219,7 @@ struct atomic_linked_pool
     /// unsafe: cannot check handle generation
     void unsafe_release_node(T* node)
     {
+        static_assert(sizeof(T) > 0, "requires complete type");
         CC_ASSERT(node >= &_pool[0] && node < &_pool[_pool_size] && "node outside of pool");
 
         if constexpr (sc_enable_gen_check)
@@ -227,7 +240,12 @@ public:
     ~atomic_linked_pool() { _destroy(); }
 
     atomic_linked_pool(atomic_linked_pool&& rhs) noexcept
-      : _pool(rhs._pool), _pool_size(rhs._pool_size), _first_free_node(cc::move(rhs._first_free_node)), _alloc(rhs._alloc), _generation(rhs._generation)
+      : _pool(rhs._pool),
+        _pool_size(rhs._pool_size),
+        _first_free_node(cc::move(rhs._first_free_node)),
+        _alloc(rhs._alloc),
+        _fptr_call_all_dtors(rhs._fptr_call_all_dtors),
+        _generation(rhs._generation)
     {
         rhs._pool = nullptr;
     }
@@ -240,6 +258,7 @@ public:
         _pool_size = rhs._pool_size;
         _first_free_node = cc::move(rhs._first_free_node);
         _alloc = rhs._alloc;
+        _fptr_call_all_dtors = rhs._fptr_call_all_dtors;
         _generation = rhs._generation;
 
         rhs._pool = nullptr;
@@ -259,7 +278,15 @@ private:
     {
         sc_num_padding_bits = 3,
         sc_num_index_bits = 16,
-        sc_num_generation_bits = 32 - (sc_num_padding_bits + sc_num_index_bits)
+        sc_num_generation_bits = 32 - (sc_num_padding_bits + sc_num_index_bits),
+
+        // masks non-padding bytes
+        // 0b000 <..#sc_num_padding_bits..> 000111 <..rest of uint32..> 111
+        sc_padding_mask = ((uint32_t(1) << (32 - sc_num_padding_bits)) - 1),
+
+        // largest possible index that can be stored in the handle
+        sc_max_size_with_gen_check = (1u << sc_num_index_bits) - 1,
+        sc_max_size_without_gen_check = (1u << (32 - sc_num_padding_bits)) - 1
     };
 
     struct internal_handle_t
@@ -324,13 +351,7 @@ private:
         else
         {
             // we use the handle as-is, but mask out the padding
-            // mask is
-            // 0b000 <..#sc_num_padding_bits..> 000111 <..rest of uint32..> 111
-            enum : uint32_t
-            {
-                e_padding_mask = ((uint32_t(1) << (32 - sc_num_padding_bits)) - 1)
-            };
-            return handle & e_padding_mask;
+            return handle & sc_padding_mask;
         }
     }
 
@@ -373,6 +394,9 @@ private:
     {
         if (_pool)
         {
+            if (_fptr_call_all_dtors)
+                _fptr_call_all_dtors(*this);
+
             _alloc->free(_pool);
             _pool = nullptr;
             _pool_size = 0;
@@ -390,6 +414,10 @@ private:
 
     std::atomic<T*> _first_free_node = nullptr;
     cc::allocator* _alloc = nullptr;
+
+    // function pointer that calls all dtors, used in _destroy() to work with fwd-declared types
+    // only non-null if T has a dtor
+    void (*_fptr_call_all_dtors)(atomic_linked_pool&) = nullptr;
 
     // this field is useless for instances without generational checks,
     // but the impact is likely not worth the trouble of conditional inheritance

--- a/src/clean-core/atomic_linked_pool.hh
+++ b/src/clean-core/atomic_linked_pool.hh
@@ -255,12 +255,17 @@ private:
     static constexpr bool sc_enable_gen_check = GenCheckEnabled;
 #endif
 
-    static constexpr size_t sc_num_padding_bits = 3;
-    static constexpr size_t sc_num_index_bits = 16;
+    enum : size_t
+    {
+        sc_num_padding_bits = 3,
+        sc_num_index_bits = 16,
+        sc_num_generation_bits = 32 - (sc_num_padding_bits + sc_num_index_bits)
+    };
+
     struct internal_handle_t
     {
         uint32_t index : sc_num_index_bits; // least significant
-        uint32_t generation : 32 - (sc_num_padding_bits + sc_num_index_bits);
+        uint32_t generation : sc_num_generation_bits;
         uint32_t padding : sc_num_padding_bits; // most significant
     };
     static_assert(sizeof(internal_handle_t) == sizeof(handle_t));

--- a/src/clean-core/detail/lib/StackWalker.cc
+++ b/src/clean-core/detail/lib/StackWalker.cc
@@ -1,0 +1,1412 @@
+/**********************************************************************
+ *
+ * StackWalker.cpp
+ * https://github.com/JochenKalmbach/StackWalker
+ *
+ * Old location: http://stackwalker.codeplex.com/
+ *
+ *
+ * History:
+ *  2005-07-27   v1    - First public release on http://www.codeproject.com/
+ *                       http://www.codeproject.com/threads/StackWalker.asp
+ *  2005-07-28   v2    - Changed the params of the constructor and ShowCallstack
+ *                       (to simplify the usage)
+ *  2005-08-01   v3    - Changed to use 'CONTEXT_FULL' instead of CONTEXT_ALL
+ *                       (should also be enough)
+ *                     - Changed to compile correctly with the PSDK of VC7.0
+ *                       (GetFileVersionInfoSizeA and GetFileVersionInfoA is wrongly defined:
+ *                        it uses LPSTR instead of LPCSTR as first parameter)
+ *                     - Added declarations to support VC5/6 without using 'dbghelp.h'
+ *                     - Added a 'pUserData' member to the ShowCallstack function and the
+ *                       PReadProcessMemoryRoutine declaration (to pass some user-defined data,
+ *                       which can be used in the readMemoryFunction-callback)
+ *  2005-08-02   v4    - OnSymInit now also outputs the OS-Version by default
+ *                     - Added example for doing an exception-callstack-walking in main.cpp
+ *                       (thanks to owillebo: http://www.codeproject.com/script/profile/whos_who.asp?id=536268)
+ *  2005-08-05   v5    - Removed most Lint (http://www.gimpel.com/) errors... thanks to Okko Willeboordse!
+ *  2008-08-04   v6    - Fixed Bug: Missing LEAK-end-tag
+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2502890#xx2502890xx
+ *                       Fixed Bug: Compiled with "WIN32_LEAN_AND_MEAN"
+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=1824718#xx1824718xx
+ *                       Fixed Bug: Compiling with "/Wall"
+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2638243#xx2638243xx
+ *                       Fixed Bug: Now checking SymUseSymSrv
+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1388979#xx1388979xx
+ *                       Fixed Bug: Support for recursive function calls
+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1434538#xx1434538xx
+ *                       Fixed Bug: Missing FreeLibrary call in "GetModuleListTH32"
+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=1326923#xx1326923xx
+ *                       Fixed Bug: SymDia is number 7, not 9!
+ *  2008-09-11   v7      For some (undocumented) reason, dbhelp.h is needing a packing of 8!
+ *                       Thanks to Teajay which reported the bug...
+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=2718933#xx2718933xx
+ *  2008-11-27   v8      Debugging Tools for Windows are now stored in a different directory
+ *                       Thanks to Luiz Salamon which reported this "bug"...
+ *                       http://www.codeproject.com/KB/threads/StackWalker.aspx?msg=2822736#xx2822736xx
+ *  2009-04-10   v9      License slightly corrected (<ORGANIZATION> replaced)
+ *  2009-11-01   v10     Moved to http://stackwalker.codeplex.com/
+ *  2009-11-02   v11     Now try to use IMAGEHLP_MODULE64_V3 if available
+ *  2010-04-15   v12     Added support for VS2010 RTM
+ *  2010-05-25   v13     Now using secure MyStrcCpy. Thanks to luke.simon:
+ *                       http://www.codeproject.com/KB/applications/leakfinder.aspx?msg=3477467#xx3477467xx
+ *  2013-01-07   v14     Runtime Check Error VS2010 Debug Builds fixed:
+ *                       http://stackwalker.codeplex.com/workitem/10511
+ *
+ *
+ * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
+ *
+ *   Copyright (c) 2005-2013, Jochen Kalmbach
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *   Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **********************************************************************/
+
+#ifdef _WIN32
+#include "StackWalker.hh"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <tchar.h>
+#include <windows.h>
+#pragma comment(lib, "version.lib") // for "VerQueryValue"
+#pragma warning(disable : 4826)
+
+
+// If VC7 and later, then use the shipped 'dbghelp.h'-file
+#pragma pack(push, 8)
+#if _MSC_VER >= 1300
+#include <dbghelp.h>
+#else
+// inline the important dbghelp.h-declarations...
+typedef enum
+{
+    SymNone = 0,
+    SymCoff,
+    SymCv,
+    SymPdb,
+    SymExport,
+    SymDeferred,
+    SymSym,
+    SymDia,
+    SymVirtual,
+    NumSymTypes
+} SYM_TYPE;
+typedef struct _IMAGEHLP_LINE64
+{
+    DWORD SizeOfStruct; // set to sizeof(IMAGEHLP_LINE64)
+    PVOID Key;          // internal
+    DWORD LineNumber;   // line number in file
+    PCHAR FileName;     // full filename
+    DWORD64 Address;    // first instruction of line
+} IMAGEHLP_LINE64, *PIMAGEHLP_LINE64;
+typedef struct _IMAGEHLP_MODULE64
+{
+    DWORD SizeOfStruct;        // set to sizeof(IMAGEHLP_MODULE64)
+    DWORD64 BaseOfImage;       // base load address of module
+    DWORD ImageSize;           // virtual size of the loaded module
+    DWORD TimeDateStamp;       // date/time stamp from pe header
+    DWORD CheckSum;            // checksum from the pe header
+    DWORD NumSyms;             // number of symbols in the symbol table
+    SYM_TYPE SymType;          // type of symbols loaded
+    CHAR ModuleName[32];       // module name
+    CHAR ImageName[256];       // image name
+    CHAR LoadedImageName[256]; // symbol file name
+} IMAGEHLP_MODULE64, *PIMAGEHLP_MODULE64;
+typedef struct _IMAGEHLP_SYMBOL64
+{
+    DWORD SizeOfStruct;  // set to sizeof(IMAGEHLP_SYMBOL64)
+    DWORD64 Address;     // virtual address including dll base address
+    DWORD Size;          // estimated size of symbol, can be zero
+    DWORD Flags;         // info about the symbols, see the SYMF defines
+    DWORD MaxNameLength; // maximum size of symbol name in 'Name'
+    CHAR Name[1];        // symbol name (null terminated string)
+} IMAGEHLP_SYMBOL64, *PIMAGEHLP_SYMBOL64;
+typedef enum
+{
+    AddrMode1616,
+    AddrMode1632,
+    AddrModeReal,
+    AddrModeFlat
+} ADDRESS_MODE;
+typedef struct _tagADDRESS64
+{
+    DWORD64 Offset;
+    WORD Segment;
+    ADDRESS_MODE Mode;
+} ADDRESS64, *LPADDRESS64;
+typedef struct _KDHELP64
+{
+    DWORD64 Thread;
+    DWORD ThCallbackStack;
+    DWORD ThCallbackBStore;
+    DWORD NextCallback;
+    DWORD FramePointer;
+    DWORD64 KiCallUserMode;
+    DWORD64 KeUserCallbackDispatcher;
+    DWORD64 SystemRangeStart;
+    DWORD64 Reserved[8];
+} KDHELP64, *PKDHELP64;
+typedef struct _tagSTACKFRAME64
+{
+    ADDRESS64 AddrPC;     // program counter
+    ADDRESS64 AddrReturn; // return address
+    ADDRESS64 AddrFrame;  // frame pointer
+    ADDRESS64 AddrStack;  // stack pointer
+    ADDRESS64 AddrBStore; // backing store pointer
+    PVOID FuncTableEntry; // pointer to pdata/fpo or NULL
+    DWORD64 Params[4];    // possible arguments to the function
+    BOOL Far;             // WOW far call
+    BOOL Virtual;         // is this a virtual frame?
+    DWORD64 Reserved[3];
+    KDHELP64 KdHelp;
+} STACKFRAME64, *LPSTACKFRAME64;
+typedef BOOL(__stdcall* PREAD_PROCESS_MEMORY_ROUTINE64)(HANDLE hProcess, DWORD64 qwBaseAddress, PVOID lpBuffer, DWORD nSize, LPDWORD lpNumberOfBytesRead);
+typedef PVOID(__stdcall* PFUNCTION_TABLE_ACCESS_ROUTINE64)(HANDLE hProcess, DWORD64 AddrBase);
+typedef DWORD64(__stdcall* PGET_MODULE_BASE_ROUTINE64)(HANDLE hProcess, DWORD64 Address);
+typedef DWORD64(__stdcall* PTRANSLATE_ADDRESS_ROUTINE64)(HANDLE hProcess, HANDLE hThread, LPADDRESS64 lpaddr);
+
+// clang-format off
+#define SYMOPT_CASE_INSENSITIVE         0x00000001
+#define SYMOPT_UNDNAME                  0x00000002
+#define SYMOPT_DEFERRED_LOADS           0x00000004
+#define SYMOPT_NO_CPP                   0x00000008
+#define SYMOPT_LOAD_LINES               0x00000010
+#define SYMOPT_OMAP_FIND_NEAREST        0x00000020
+#define SYMOPT_LOAD_ANYTHING            0x00000040
+#define SYMOPT_IGNORE_CVREC             0x00000080
+#define SYMOPT_NO_UNQUALIFIED_LOADS     0x00000100
+#define SYMOPT_FAIL_CRITICAL_ERRORS     0x00000200
+#define SYMOPT_EXACT_SYMBOLS            0x00000400
+#define SYMOPT_ALLOW_ABSOLUTE_SYMBOLS   0x00000800
+#define SYMOPT_IGNORE_NT_SYMPATH        0x00001000
+#define SYMOPT_INCLUDE_32BIT_MODULES    0x00002000
+#define SYMOPT_PUBLICS_ONLY             0x00004000
+#define SYMOPT_NO_PUBLICS               0x00008000
+#define SYMOPT_AUTO_PUBLICS             0x00010000
+#define SYMOPT_NO_IMAGE_SEARCH          0x00020000
+#define SYMOPT_SECURE                   0x00040000
+#define SYMOPT_DEBUG                    0x80000000
+#define UNDNAME_COMPLETE                 (0x0000) // Enable full undecoration
+#define UNDNAME_NAME_ONLY                (0x1000) // Crack only the name for primary declaration;
+// clang-format on
+
+#endif // _MSC_VER < 1300
+#pragma pack(pop)
+
+// Some missing defines (for VC5/6):
+#ifndef INVALID_FILE_ATTRIBUTES
+#define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
+#endif
+
+// secure-CRT_functions are only available starting with VC8
+#if _MSC_VER < 1400
+#define strcpy_s(dst, len, src) strcpy(dst, src)
+#define strncpy_s(dst, len, src, maxLen) strncpy(dst, len, src)
+#define strcat_s(dst, len, src) strcat(dst, src)
+#define _snprintf_s _snprintf
+#define _tcscat_s _tcscat
+#endif
+
+static void MyStrCpy(char* szDest, size_t nMaxDestSize, const char* szSrc)
+{
+    if (nMaxDestSize <= 0)
+        return;
+    strncpy_s(szDest, nMaxDestSize, szSrc, _TRUNCATE);
+    // INFO: _TRUNCATE will ensure that it is null-terminated;
+    // but with older compilers (<1400) it uses "strncpy" and this does not!)
+    szDest[nMaxDestSize - 1] = 0;
+} // MyStrCpy
+
+// Normally it should be enough to use 'CONTEXT_FULL' (better would be 'CONTEXT_ALL')
+#define USED_CONTEXT_FLAGS CONTEXT_FULL
+
+class StackWalkerInternal
+{
+public:
+    StackWalkerInternal(StackWalker* parent, HANDLE hProcess)
+    {
+        m_parent = parent;
+        m_hDbhHelp = NULL;
+        pSC = NULL;
+        m_hProcess = hProcess;
+        m_szSymPath = NULL;
+        pSFTA = NULL;
+        pSGLFA = NULL;
+        pSGMB = NULL;
+        pSGMI = NULL;
+        pSGO = NULL;
+        pSGSFA = NULL;
+        pSI = NULL;
+        pSLM = NULL;
+        pSSO = NULL;
+        pSW = NULL;
+        pUDSN = NULL;
+        pSGSP = NULL;
+    }
+    ~StackWalkerInternal()
+    {
+        if (pSC != NULL)
+            pSC(m_hProcess); // SymCleanup
+        if (m_hDbhHelp != NULL)
+            FreeLibrary(m_hDbhHelp);
+        m_hDbhHelp = NULL;
+        m_parent = NULL;
+        if (m_szSymPath != NULL)
+            free(m_szSymPath);
+        m_szSymPath = NULL;
+    }
+    BOOL Init(LPCSTR szSymPath)
+    {
+        if (m_parent == NULL)
+            return FALSE;
+        // Dynamically load the Entry-Points for dbghelp.dll:
+        // First try to load the newest one from
+        TCHAR szTemp[4096];
+        // But before we do this, we first check if the ".local" file exists
+        if (GetModuleFileName(NULL, szTemp, 4096) > 0)
+        {
+            _tcscat_s(szTemp, _T(".local"));
+            if (GetFileAttributes(szTemp) == INVALID_FILE_ATTRIBUTES)
+            {
+                // ".local" file does not exist, so we can try to load the dbghelp.dll from the "Debugging Tools for Windows"
+                // Ok, first try the new path according to the architecture:
+#ifdef _M_IX86
+                if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+                {
+                    _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x86)\\dbghelp.dll"));
+                    // now check if the file exists:
+                    if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+                    {
+                        m_hDbhHelp = LoadLibrary(szTemp);
+                    }
+                }
+#elif _M_X64
+                if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+                {
+                    _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x64)\\dbghelp.dll"));
+                    // now check if the file exists:
+                    if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+                    {
+                        m_hDbhHelp = LoadLibrary(szTemp);
+                    }
+                }
+#elif _M_IA64
+                if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+                {
+                    _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (ia64)\\dbghelp.dll"));
+                    // now check if the file exists:
+                    if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+                    {
+                        m_hDbhHelp = LoadLibrary(szTemp);
+                    }
+                }
+#endif
+                // If still not found, try the old directories...
+                if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+                {
+                    _tcscat_s(szTemp, _T("\\Debugging Tools for Windows\\dbghelp.dll"));
+                    // now check if the file exists:
+                    if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+                    {
+                        m_hDbhHelp = LoadLibrary(szTemp);
+                    }
+                }
+#if defined _M_X64 || defined _M_IA64
+                // Still not found? Then try to load the (old) 64-Bit version:
+                if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+                {
+                    _tcscat_s(szTemp, _T("\\Debugging Tools for Windows 64-Bit\\dbghelp.dll"));
+                    if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+                    {
+                        m_hDbhHelp = LoadLibrary(szTemp);
+                    }
+                }
+#endif
+            }
+        }
+        if (m_hDbhHelp == NULL) // if not already loaded, try to load a default-one
+            m_hDbhHelp = LoadLibrary(_T("dbghelp.dll"));
+        if (m_hDbhHelp == NULL)
+            return FALSE;
+        pSI = (tSI)GetProcAddress(m_hDbhHelp, "SymInitialize");
+        pSC = (tSC)GetProcAddress(m_hDbhHelp, "SymCleanup");
+
+        pSW = (tSW)GetProcAddress(m_hDbhHelp, "StackWalk64");
+        pSGO = (tSGO)GetProcAddress(m_hDbhHelp, "SymGetOptions");
+        pSSO = (tSSO)GetProcAddress(m_hDbhHelp, "SymSetOptions");
+
+        pSFTA = (tSFTA)GetProcAddress(m_hDbhHelp, "SymFunctionTableAccess64");
+        pSGLFA = (tSGLFA)GetProcAddress(m_hDbhHelp, "SymGetLineFromAddr64");
+        pSGMB = (tSGMB)GetProcAddress(m_hDbhHelp, "SymGetModuleBase64");
+        pSGMI = (tSGMI)GetProcAddress(m_hDbhHelp, "SymGetModuleInfo64");
+        pSGSFA = (tSGSFA)GetProcAddress(m_hDbhHelp, "SymGetSymFromAddr64");
+        pUDSN = (tUDSN)GetProcAddress(m_hDbhHelp, "UnDecorateSymbolName");
+        pSLM = (tSLM)GetProcAddress(m_hDbhHelp, "SymLoadModule64");
+        pSGSP = (tSGSP)GetProcAddress(m_hDbhHelp, "SymGetSearchPath");
+
+        if (pSC == NULL || pSFTA == NULL || pSGMB == NULL || pSGMI == NULL || pSGO == NULL || pSGSFA == NULL || pSI == NULL || pSSO == NULL
+            || pSW == NULL || pUDSN == NULL || pSLM == NULL)
+        {
+            FreeLibrary(m_hDbhHelp);
+            m_hDbhHelp = NULL;
+            pSC = NULL;
+            return FALSE;
+        }
+
+        // SymInitialize
+        if (szSymPath != NULL)
+            m_szSymPath = _strdup(szSymPath);
+        if (this->pSI(m_hProcess, m_szSymPath, FALSE) == FALSE)
+            this->m_parent->OnDbgHelpErr("SymInitialize", GetLastError(), 0);
+
+        DWORD symOptions = this->pSGO(); // SymGetOptions
+        symOptions |= SYMOPT_LOAD_LINES;
+        symOptions |= SYMOPT_FAIL_CRITICAL_ERRORS;
+        // symOptions |= SYMOPT_NO_PROMPTS;
+        // SymSetOptions
+        symOptions = this->pSSO(symOptions);
+
+        char buf[StackWalker::STACKWALK_MAX_NAMELEN] = {0};
+        if (this->pSGSP != NULL)
+        {
+            if (this->pSGSP(m_hProcess, buf, StackWalker::STACKWALK_MAX_NAMELEN) == FALSE)
+                this->m_parent->OnDbgHelpErr("SymGetSearchPath", GetLastError(), 0);
+        }
+        char szUserName[1024] = {0};
+        DWORD dwSize = 1024;
+        GetUserNameA(szUserName, &dwSize);
+        this->m_parent->OnSymInit(buf, symOptions, szUserName);
+
+        return TRUE;
+    }
+
+    StackWalker* m_parent;
+
+    HMODULE m_hDbhHelp;
+    HANDLE m_hProcess;
+    LPSTR m_szSymPath;
+
+#pragma pack(push, 8)
+    typedef struct IMAGEHLP_MODULE64_V3
+    {
+        DWORD SizeOfStruct;        // set to sizeof(IMAGEHLP_MODULE64)
+        DWORD64 BaseOfImage;       // base load address of module
+        DWORD ImageSize;           // virtual size of the loaded module
+        DWORD TimeDateStamp;       // date/time stamp from pe header
+        DWORD CheckSum;            // checksum from the pe header
+        DWORD NumSyms;             // number of symbols in the symbol table
+        SYM_TYPE SymType;          // type of symbols loaded
+        CHAR ModuleName[32];       // module name
+        CHAR ImageName[256];       // image name
+        CHAR LoadedImageName[256]; // symbol file name
+        // new elements: 07-Jun-2002
+        CHAR LoadedPdbName[256];   // pdb file name
+        DWORD CVSig;               // Signature of the CV record in the debug directories
+        CHAR CVData[MAX_PATH * 3]; // Contents of the CV record
+        DWORD PdbSig;              // Signature of PDB
+        GUID PdbSig70;             // Signature of PDB (VC 7 and up)
+        DWORD PdbAge;              // DBI age of pdb
+        BOOL PdbUnmatched;         // loaded an unmatched pdb
+        BOOL DbgUnmatched;         // loaded an unmatched dbg
+        BOOL LineNumbers;          // we have line number information
+        BOOL GlobalSymbols;        // we have internal symbol information
+        BOOL TypeInfo;             // we have type information
+        // new elements: 17-Dec-2003
+        BOOL SourceIndexed; // pdb supports source server
+        BOOL Publics;       // contains public symbols
+    };
+
+    typedef struct IMAGEHLP_MODULE64_V2
+    {
+        DWORD SizeOfStruct;        // set to sizeof(IMAGEHLP_MODULE64)
+        DWORD64 BaseOfImage;       // base load address of module
+        DWORD ImageSize;           // virtual size of the loaded module
+        DWORD TimeDateStamp;       // date/time stamp from pe header
+        DWORD CheckSum;            // checksum from the pe header
+        DWORD NumSyms;             // number of symbols in the symbol table
+        SYM_TYPE SymType;          // type of symbols loaded
+        CHAR ModuleName[32];       // module name
+        CHAR ImageName[256];       // image name
+        CHAR LoadedImageName[256]; // symbol file name
+    };
+#pragma pack(pop)
+
+    // SymCleanup()
+    typedef BOOL(__stdcall* tSC)(IN HANDLE hProcess);
+    tSC pSC;
+
+    // SymFunctionTableAccess64()
+    typedef PVOID(__stdcall* tSFTA)(HANDLE hProcess, DWORD64 AddrBase);
+    tSFTA pSFTA;
+
+    // SymGetLineFromAddr64()
+    typedef BOOL(__stdcall* tSGLFA)(IN HANDLE hProcess, IN DWORD64 dwAddr, OUT PDWORD pdwDisplacement, OUT PIMAGEHLP_LINE64 Line);
+    tSGLFA pSGLFA;
+
+    // SymGetModuleBase64()
+    typedef DWORD64(__stdcall* tSGMB)(IN HANDLE hProcess, IN DWORD64 dwAddr);
+    tSGMB pSGMB;
+
+    // SymGetModuleInfo64()
+    typedef BOOL(__stdcall* tSGMI)(IN HANDLE hProcess, IN DWORD64 dwAddr, OUT IMAGEHLP_MODULE64_V3* ModuleInfo);
+    tSGMI pSGMI;
+
+    // SymGetOptions()
+    typedef DWORD(__stdcall* tSGO)(VOID);
+    tSGO pSGO;
+
+    // SymGetSymFromAddr64()
+    typedef BOOL(__stdcall* tSGSFA)(IN HANDLE hProcess, IN DWORD64 dwAddr, OUT PDWORD64 pdwDisplacement, OUT PIMAGEHLP_SYMBOL64 Symbol);
+    tSGSFA pSGSFA;
+
+    // SymInitialize()
+    typedef BOOL(__stdcall* tSI)(IN HANDLE hProcess, IN PSTR UserSearchPath, IN BOOL fInvadeProcess);
+    tSI pSI;
+
+    // SymLoadModule64()
+    typedef DWORD64(__stdcall* tSLM)(IN HANDLE hProcess, IN HANDLE hFile, IN PSTR ImageName, IN PSTR ModuleName, IN DWORD64 BaseOfDll, IN DWORD SizeOfDll);
+    tSLM pSLM;
+
+    // SymSetOptions()
+    typedef DWORD(__stdcall* tSSO)(IN DWORD SymOptions);
+    tSSO pSSO;
+
+    // StackWalk64()
+    typedef BOOL(__stdcall* tSW)(DWORD MachineType,
+                                 HANDLE hProcess,
+                                 HANDLE hThread,
+                                 LPSTACKFRAME64 StackFrame,
+                                 PVOID ContextRecord,
+                                 PREAD_PROCESS_MEMORY_ROUTINE64 ReadMemoryRoutine,
+                                 PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine,
+                                 PGET_MODULE_BASE_ROUTINE64 GetModuleBaseRoutine,
+                                 PTRANSLATE_ADDRESS_ROUTINE64 TranslateAddress);
+    tSW pSW;
+
+    // UnDecorateSymbolName()
+    typedef DWORD(__stdcall WINAPI* tUDSN)(PCSTR DecoratedName, PSTR UnDecoratedName, DWORD UndecoratedLength, DWORD Flags);
+    tUDSN pUDSN;
+
+    typedef BOOL(__stdcall WINAPI* tSGSP)(HANDLE hProcess, PSTR SearchPath, DWORD SearchPathLength);
+    tSGSP pSGSP;
+
+private:
+// **************************************** ToolHelp32 ************************
+#define MAX_MODULE_NAME32 255
+#define TH32CS_SNAPMODULE 0x00000008
+#pragma pack(push, 8)
+    typedef struct tagMODULEENTRY32
+    {
+        DWORD dwSize;
+        DWORD th32ModuleID;  // This module
+        DWORD th32ProcessID; // owning process
+        DWORD GlblcntUsage;  // Global usage count on the module
+        DWORD ProccntUsage;  // Module usage count in th32ProcessID's context
+        BYTE* modBaseAddr;   // Base address of module in th32ProcessID's context
+        DWORD modBaseSize;   // Size in bytes of module starting at modBaseAddr
+        HMODULE hModule;     // The hModule of this module in th32ProcessID's context
+        char szModule[MAX_MODULE_NAME32 + 1];
+        char szExePath[MAX_PATH];
+    } MODULEENTRY32;
+    typedef MODULEENTRY32* PMODULEENTRY32;
+    typedef MODULEENTRY32* LPMODULEENTRY32;
+#pragma pack(pop)
+
+    BOOL GetModuleListTH32(HANDLE hProcess, DWORD pid)
+    {
+        // CreateToolhelp32Snapshot()
+        typedef HANDLE(__stdcall * tCT32S)(DWORD dwFlags, DWORD th32ProcessID);
+        // Module32First()
+        typedef BOOL(__stdcall * tM32F)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
+        // Module32Next()
+        typedef BOOL(__stdcall * tM32N)(HANDLE hSnapshot, LPMODULEENTRY32 lpme);
+
+        // try both dlls...
+        const TCHAR* dllname[] = {_T("kernel32.dll"), _T("tlhelp32.dll")};
+        HINSTANCE hToolhelp = NULL;
+        tCT32S pCT32S = NULL;
+        tM32F pM32F = NULL;
+        tM32N pM32N = NULL;
+
+        HANDLE hSnap;
+        MODULEENTRY32 me;
+        me.dwSize = sizeof(me);
+        BOOL keepGoing;
+        size_t i;
+
+        for (i = 0; i < (sizeof(dllname) / sizeof(dllname[0])); i++)
+        {
+            hToolhelp = LoadLibrary(dllname[i]);
+            if (hToolhelp == NULL)
+                continue;
+            pCT32S = (tCT32S)GetProcAddress(hToolhelp, "CreateToolhelp32Snapshot");
+            pM32F = (tM32F)GetProcAddress(hToolhelp, "Module32First");
+            pM32N = (tM32N)GetProcAddress(hToolhelp, "Module32Next");
+            if ((pCT32S != NULL) && (pM32F != NULL) && (pM32N != NULL))
+                break; // found the functions!
+            FreeLibrary(hToolhelp);
+            hToolhelp = NULL;
+        }
+
+        if (hToolhelp == NULL)
+            return FALSE;
+
+        hSnap = pCT32S(TH32CS_SNAPMODULE, pid);
+        if (hSnap == (HANDLE)-1)
+        {
+            FreeLibrary(hToolhelp);
+            return FALSE;
+        }
+
+        keepGoing = !!pM32F(hSnap, &me);
+        int cnt = 0;
+        while (keepGoing)
+        {
+            this->LoadModule(hProcess, me.szExePath, me.szModule, (DWORD64)me.modBaseAddr, me.modBaseSize);
+            cnt++;
+            keepGoing = !!pM32N(hSnap, &me);
+        }
+        CloseHandle(hSnap);
+        FreeLibrary(hToolhelp);
+        if (cnt <= 0)
+            return FALSE;
+        return TRUE;
+    } // GetModuleListTH32
+
+    // **************************************** PSAPI ************************
+    typedef struct _MODULEINFO
+    {
+        LPVOID lpBaseOfDll;
+        DWORD SizeOfImage;
+        LPVOID EntryPoint;
+    } MODULEINFO, *LPMODULEINFO;
+
+    BOOL GetModuleListPSAPI(HANDLE hProcess)
+    {
+        // EnumProcessModules()
+        typedef BOOL(__stdcall * tEPM)(HANDLE hProcess, HMODULE * lphModule, DWORD cb, LPDWORD lpcbNeeded);
+        // GetModuleFileNameEx()
+        typedef DWORD(__stdcall * tGMFNE)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename, DWORD nSize);
+        // GetModuleBaseName()
+        typedef DWORD(__stdcall * tGMBN)(HANDLE hProcess, HMODULE hModule, LPSTR lpFilename, DWORD nSize);
+        // GetModuleInformation()
+        typedef BOOL(__stdcall * tGMI)(HANDLE hProcess, HMODULE hModule, LPMODULEINFO pmi, DWORD nSize);
+
+        HINSTANCE hPsapi;
+        tEPM pEPM;
+        tGMFNE pGMFNE;
+        tGMBN pGMBN;
+        tGMI pGMI;
+
+        DWORD i;
+        // ModuleEntry e;
+        DWORD cbNeeded;
+        MODULEINFO mi;
+        HMODULE* hMods = NULL;
+        char* tt = NULL;
+        char* tt2 = NULL;
+        const SIZE_T TTBUFLEN = 8096;
+        int cnt = 0;
+
+        hPsapi = LoadLibrary(_T("psapi.dll"));
+        if (hPsapi == NULL)
+            return FALSE;
+
+        pEPM = (tEPM)GetProcAddress(hPsapi, "EnumProcessModules");
+        pGMFNE = (tGMFNE)GetProcAddress(hPsapi, "GetModuleFileNameExA");
+        pGMBN = (tGMFNE)GetProcAddress(hPsapi, "GetModuleBaseNameA");
+        pGMI = (tGMI)GetProcAddress(hPsapi, "GetModuleInformation");
+        if ((pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL))
+        {
+            // we couldn't find all functions
+            FreeLibrary(hPsapi);
+            return FALSE;
+        }
+
+        hMods = (HMODULE*)malloc(sizeof(HMODULE) * (TTBUFLEN / sizeof(HMODULE)));
+        tt = (char*)malloc(sizeof(char) * TTBUFLEN);
+        tt2 = (char*)malloc(sizeof(char) * TTBUFLEN);
+        if ((hMods == NULL) || (tt == NULL) || (tt2 == NULL))
+            goto cleanup;
+
+        if (!pEPM(hProcess, hMods, TTBUFLEN, &cbNeeded))
+        {
+            //_ftprintf(fLogFile, _T("%lu: EPM failed, GetLastError = %lu\n"), g_dwShowCount, gle );
+            goto cleanup;
+        }
+
+        if (cbNeeded > TTBUFLEN)
+        {
+            //_ftprintf(fLogFile, _T("%lu: More than %lu module handles. Huh?\n"), g_dwShowCount, lenof( hMods ) );
+            goto cleanup;
+        }
+
+        for (i = 0; i < cbNeeded / sizeof(hMods[0]); i++)
+        {
+            // base address, size
+            pGMI(hProcess, hMods[i], &mi, sizeof(mi));
+            // image file name
+            tt[0] = 0;
+            pGMFNE(hProcess, hMods[i], tt, TTBUFLEN);
+            // module name
+            tt2[0] = 0;
+            pGMBN(hProcess, hMods[i], tt2, TTBUFLEN);
+
+            DWORD dwRes = this->LoadModule(hProcess, tt, tt2, (DWORD64)mi.lpBaseOfDll, mi.SizeOfImage);
+            if (dwRes != ERROR_SUCCESS)
+                this->m_parent->OnDbgHelpErr("LoadModule", dwRes, 0);
+            cnt++;
+        }
+
+    cleanup:
+        if (hPsapi != NULL)
+            FreeLibrary(hPsapi);
+        if (tt2 != NULL)
+            free(tt2);
+        if (tt != NULL)
+            free(tt);
+        if (hMods != NULL)
+            free(hMods);
+
+        return cnt != 0;
+    } // GetModuleListPSAPI
+
+    DWORD LoadModule(HANDLE hProcess, LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size)
+    {
+        CHAR* szImg = _strdup(img);
+        CHAR* szMod = _strdup(mod);
+        DWORD result = ERROR_SUCCESS;
+        if ((szImg == NULL) || (szMod == NULL))
+            result = ERROR_NOT_ENOUGH_MEMORY;
+        else
+        {
+            if (pSLM(hProcess, 0, szImg, szMod, baseAddr, size) == 0)
+                result = GetLastError();
+        }
+        ULONGLONG fileVersion = 0;
+        if ((m_parent != NULL) && (szImg != NULL))
+        {
+            // try to retrieve the file-version:
+            if ((this->m_parent->m_options & StackWalker::RetrieveFileVersion) != 0)
+            {
+                VS_FIXEDFILEINFO* fInfo = NULL;
+                DWORD dwHandle;
+                DWORD dwSize = GetFileVersionInfoSizeA(szImg, &dwHandle);
+                if (dwSize > 0)
+                {
+                    LPVOID vData = malloc(dwSize);
+                    if (vData != NULL)
+                    {
+                        if (GetFileVersionInfoA(szImg, dwHandle, dwSize, vData) != 0)
+                        {
+                            UINT len;
+                            TCHAR szSubBlock[] = _T("\\");
+                            if (VerQueryValue(vData, szSubBlock, (LPVOID*)&fInfo, &len) == 0)
+                                fInfo = NULL;
+                            else
+                            {
+                                fileVersion = ((ULONGLONG)fInfo->dwFileVersionLS) + ((ULONGLONG)fInfo->dwFileVersionMS << 32);
+                            }
+                        }
+                        free(vData);
+                    }
+                }
+            }
+
+            // Retrieve some additional-infos about the module
+            IMAGEHLP_MODULE64_V3 Module;
+            const char* szSymType = "-unknown-";
+            if (this->GetModuleInfo(hProcess, baseAddr, &Module) != FALSE)
+            {
+                switch (Module.SymType)
+                {
+                case SymNone:
+                    szSymType = "-nosymbols-";
+                    break;
+                case SymCoff: // 1
+                    szSymType = "COFF";
+                    break;
+                case SymCv: // 2
+                    szSymType = "CV";
+                    break;
+                case SymPdb: // 3
+                    szSymType = "PDB";
+                    break;
+                case SymExport: // 4
+                    szSymType = "-exported-";
+                    break;
+                case SymDeferred: // 5
+                    szSymType = "-deferred-";
+                    break;
+                case SymSym: // 6
+                    szSymType = "SYM";
+                    break;
+                case 7: // SymDia:
+                    szSymType = "DIA";
+                    break;
+                case 8: // SymVirtual:
+                    szSymType = "Virtual";
+                    break;
+                }
+            }
+            LPCSTR pdbName = Module.LoadedImageName;
+            if (Module.LoadedPdbName[0] != 0)
+                pdbName = Module.LoadedPdbName;
+            this->m_parent->OnLoadModule(img, mod, baseAddr, size, result, szSymType, pdbName, fileVersion);
+        }
+        if (szImg != NULL)
+            free(szImg);
+        if (szMod != NULL)
+            free(szMod);
+        return result;
+    }
+
+public:
+    BOOL LoadModules(HANDLE hProcess, DWORD dwProcessId)
+    {
+        // first try toolhelp32
+        if (GetModuleListTH32(hProcess, dwProcessId))
+            return true;
+        // then try psapi
+        return GetModuleListPSAPI(hProcess);
+    }
+
+    BOOL GetModuleInfo(HANDLE hProcess, DWORD64 baseAddr, IMAGEHLP_MODULE64_V3* pModuleInfo)
+    {
+        memset(pModuleInfo, 0, sizeof(IMAGEHLP_MODULE64_V3));
+        if (this->pSGMI == NULL)
+        {
+            SetLastError(ERROR_DLL_INIT_FAILED);
+            return FALSE;
+        }
+        // First try to use the larger ModuleInfo-Structure
+        pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
+        void* pData = malloc(4096); // reserve enough memory, so the bug in v6.3.5.1 does not lead to memory-overwrites...
+        if (pData == NULL)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            return FALSE;
+        }
+        memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V3));
+        static bool s_useV3Version = true;
+        if (s_useV3Version)
+        {
+            if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
+            {
+                // only copy as much memory as is reserved...
+                memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V3));
+                pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V3);
+                free(pData);
+                return TRUE;
+            }
+            s_useV3Version = false; // to prevent unnecessary calls with the larger struct...
+        }
+
+        // could not retrieve the bigger structure, try with the smaller one (as defined in VC7.1)...
+        pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
+        memcpy(pData, pModuleInfo, sizeof(IMAGEHLP_MODULE64_V2));
+        if (this->pSGMI(hProcess, baseAddr, (IMAGEHLP_MODULE64_V3*)pData) != FALSE)
+        {
+            // only copy as much memory as is reserved...
+            memcpy(pModuleInfo, pData, sizeof(IMAGEHLP_MODULE64_V2));
+            pModuleInfo->SizeOfStruct = sizeof(IMAGEHLP_MODULE64_V2);
+            free(pData);
+            return TRUE;
+        }
+        free(pData);
+        SetLastError(ERROR_DLL_INIT_FAILED);
+        return FALSE;
+    }
+};
+
+// #############################################################
+StackWalker::StackWalker(DWORD dwProcessId, HANDLE hProcess)
+{
+    this->m_options = OptionsAll;
+    this->m_modulesLoaded = FALSE;
+    this->m_hProcess = hProcess;
+    this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
+    this->m_dwProcessId = dwProcessId;
+    this->m_szSymPath = NULL;
+    this->m_MaxRecursionCount = 1000;
+}
+StackWalker::StackWalker(int options, LPCSTR szSymPath, DWORD dwProcessId, HANDLE hProcess)
+{
+    this->m_options = options;
+    this->m_modulesLoaded = FALSE;
+    this->m_hProcess = hProcess;
+    this->m_sw = new StackWalkerInternal(this, this->m_hProcess);
+    this->m_dwProcessId = dwProcessId;
+    if (szSymPath != NULL)
+    {
+        this->m_szSymPath = _strdup(szSymPath);
+        this->m_options |= SymBuildPath;
+    }
+    else
+        this->m_szSymPath = NULL;
+    this->m_MaxRecursionCount = 1000;
+}
+
+StackWalker::~StackWalker()
+{
+    if (m_szSymPath != NULL)
+        free(m_szSymPath);
+    m_szSymPath = NULL;
+    if (this->m_sw != NULL)
+        delete this->m_sw;
+    this->m_sw = NULL;
+}
+
+BOOL StackWalker::LoadModules()
+{
+    if (this->m_sw == NULL)
+    {
+        SetLastError(ERROR_DLL_INIT_FAILED);
+        return FALSE;
+    }
+    if (m_modulesLoaded != FALSE)
+        return TRUE;
+
+    // Build the sym-path:
+    char* szSymPath = NULL;
+    if ((this->m_options & SymBuildPath) != 0)
+    {
+        const size_t nSymPathLen = 4096;
+        szSymPath = (char*)malloc(nSymPathLen);
+        if (szSymPath == NULL)
+        {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            return FALSE;
+        }
+        szSymPath[0] = 0;
+        // Now first add the (optional) provided sympath:
+        if (this->m_szSymPath != NULL)
+        {
+            strcat_s(szSymPath, nSymPathLen, this->m_szSymPath);
+            strcat_s(szSymPath, nSymPathLen, ";");
+        }
+
+        strcat_s(szSymPath, nSymPathLen, ".;");
+
+        const size_t nTempLen = 1024;
+        char szTemp[nTempLen];
+        // Now add the current directory:
+        if (GetCurrentDirectoryA(nTempLen, szTemp) > 0)
+        {
+            szTemp[nTempLen - 1] = 0;
+            strcat_s(szSymPath, nSymPathLen, szTemp);
+            strcat_s(szSymPath, nSymPathLen, ";");
+        }
+
+        // Now add the path for the main-module:
+        if (GetModuleFileNameA(NULL, szTemp, nTempLen) > 0)
+        {
+            szTemp[nTempLen - 1] = 0;
+            for (char* p = (szTemp + strlen(szTemp) - 1); p >= szTemp; --p)
+            {
+                // locate the rightmost path separator
+                if ((*p == '\\') || (*p == '/') || (*p == ':'))
+                {
+                    *p = 0;
+                    break;
+                }
+            } // for (search for path separator...)
+            if (strlen(szTemp) > 0)
+            {
+                strcat_s(szSymPath, nSymPathLen, szTemp);
+                strcat_s(szSymPath, nSymPathLen, ";");
+            }
+        }
+        if (GetEnvironmentVariableA("_NT_SYMBOL_PATH", szTemp, nTempLen) > 0)
+        {
+            szTemp[nTempLen - 1] = 0;
+            strcat_s(szSymPath, nSymPathLen, szTemp);
+            strcat_s(szSymPath, nSymPathLen, ";");
+        }
+        if (GetEnvironmentVariableA("_NT_ALTERNATE_SYMBOL_PATH", szTemp, nTempLen) > 0)
+        {
+            szTemp[nTempLen - 1] = 0;
+            strcat_s(szSymPath, nSymPathLen, szTemp);
+            strcat_s(szSymPath, nSymPathLen, ";");
+        }
+        if (GetEnvironmentVariableA("SYSTEMROOT", szTemp, nTempLen) > 0)
+        {
+            szTemp[nTempLen - 1] = 0;
+            strcat_s(szSymPath, nSymPathLen, szTemp);
+            strcat_s(szSymPath, nSymPathLen, ";");
+            // also add the "system32"-directory:
+            strcat_s(szTemp, nTempLen, "\\system32");
+            strcat_s(szSymPath, nSymPathLen, szTemp);
+            strcat_s(szSymPath, nSymPathLen, ";");
+        }
+
+        if ((this->m_options & SymUseSymSrv) != 0)
+        {
+            if (GetEnvironmentVariableA("SYSTEMDRIVE", szTemp, nTempLen) > 0)
+            {
+                szTemp[nTempLen - 1] = 0;
+                strcat_s(szSymPath, nSymPathLen, "SRV*");
+                strcat_s(szSymPath, nSymPathLen, szTemp);
+                strcat_s(szSymPath, nSymPathLen, "\\websymbols");
+                strcat_s(szSymPath, nSymPathLen, "*https://msdl.microsoft.com/download/symbols;");
+            }
+            else
+                strcat_s(szSymPath, nSymPathLen, "SRV*c:\\websymbols*https://msdl.microsoft.com/download/symbols;");
+        }
+    } // if SymBuildPath
+
+    // First Init the whole stuff...
+    BOOL bRet = this->m_sw->Init(szSymPath);
+    if (szSymPath != NULL)
+        free(szSymPath);
+    szSymPath = NULL;
+    if (bRet == FALSE)
+    {
+        this->OnDbgHelpErr("Error while initializing dbghelp.dll", 0, 0);
+        SetLastError(ERROR_DLL_INIT_FAILED);
+        return FALSE;
+    }
+
+    bRet = this->m_sw->LoadModules(this->m_hProcess, this->m_dwProcessId);
+    if (bRet != FALSE)
+        m_modulesLoaded = TRUE;
+    return bRet;
+}
+
+// The following is used to pass the "userData"-Pointer to the user-provided readMemoryFunction
+// This has to be done due to a problem with the "hProcess"-parameter in x64...
+// Because this class is in no case multi-threading-enabled (because of the limitations
+// of dbghelp.dll) it is "safe" to use a static-variable
+static StackWalker::PReadProcessMemoryRoutine s_readMemoryFunction = NULL;
+static LPVOID s_readMemoryFunction_UserData = NULL;
+
+BOOL StackWalker::ShowCallstack(HANDLE hThread, const CONTEXT* context, PReadProcessMemoryRoutine readMemoryFunction, LPVOID pUserData)
+{
+    CONTEXT c;
+    CallstackEntry csEntry;
+    IMAGEHLP_SYMBOL64* pSym = NULL;
+    StackWalkerInternal::IMAGEHLP_MODULE64_V3 Module;
+    IMAGEHLP_LINE64 Line;
+    int frameNum;
+    bool bLastEntryCalled = true;
+    int curRecursionCount = 0;
+
+    if (m_modulesLoaded == FALSE)
+        this->LoadModules(); // ignore the result...
+
+    if (this->m_sw->m_hDbhHelp == NULL)
+    {
+        SetLastError(ERROR_DLL_INIT_FAILED);
+        return FALSE;
+    }
+
+    s_readMemoryFunction = readMemoryFunction;
+    s_readMemoryFunction_UserData = pUserData;
+
+    if (context == NULL)
+    {
+        // If no context is provided, capture the context
+        // See: https://stackwalker.codeplex.com/discussions/446958
+#if _WIN32_WINNT <= 0x0501
+        // If we need to support XP, we need to use the "old way", because "GetThreadId" is not available!
+        if (hThread == GetCurrentThread())
+#else
+        if (GetThreadId(hThread) == GetCurrentThreadId())
+#endif
+        {
+            GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, USED_CONTEXT_FLAGS);
+        }
+        else
+        {
+            SuspendThread(hThread);
+            memset(&c, 0, sizeof(CONTEXT));
+            c.ContextFlags = USED_CONTEXT_FLAGS;
+
+            // TODO: Detect if you want to get a thread context of a different process, which is running a different processor architecture...
+            // This does only work if we are x64 and the target process is x64 or x86;
+            // It cannot work, if this process is x64 and the target process is x64... this is not supported...
+            // See also: http://www.howzatt.demon.co.uk/articles/DebuggingInWin64.html
+            if (GetThreadContext(hThread, &c) == FALSE)
+            {
+                ResumeThread(hThread);
+                return FALSE;
+            }
+        }
+    }
+    else
+        c = *context;
+
+    // init STACKFRAME for first call
+    STACKFRAME64 s; // in/out stackframe
+    memset(&s, 0, sizeof(s));
+    DWORD imageType;
+#ifdef _M_IX86
+    // normally, call ImageNtHeader() and use machine info from PE header
+    imageType = IMAGE_FILE_MACHINE_I386;
+    s.AddrPC.Offset = c.Eip;
+    s.AddrPC.Mode = AddrModeFlat;
+    s.AddrFrame.Offset = c.Ebp;
+    s.AddrFrame.Mode = AddrModeFlat;
+    s.AddrStack.Offset = c.Esp;
+    s.AddrStack.Mode = AddrModeFlat;
+#elif _M_X64
+    imageType = IMAGE_FILE_MACHINE_AMD64;
+    s.AddrPC.Offset = c.Rip;
+    s.AddrPC.Mode = AddrModeFlat;
+    s.AddrFrame.Offset = c.Rsp;
+    s.AddrFrame.Mode = AddrModeFlat;
+    s.AddrStack.Offset = c.Rsp;
+    s.AddrStack.Mode = AddrModeFlat;
+#elif _M_IA64
+    imageType = IMAGE_FILE_MACHINE_IA64;
+    s.AddrPC.Offset = c.StIIP;
+    s.AddrPC.Mode = AddrModeFlat;
+    s.AddrFrame.Offset = c.IntSp;
+    s.AddrFrame.Mode = AddrModeFlat;
+    s.AddrBStore.Offset = c.RsBSP;
+    s.AddrBStore.Mode = AddrModeFlat;
+    s.AddrStack.Offset = c.IntSp;
+    s.AddrStack.Mode = AddrModeFlat;
+#else
+#error "Platform not supported!"
+#endif
+
+    pSym = (IMAGEHLP_SYMBOL64*)malloc(sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+    if (!pSym)
+        goto cleanup; // not enough memory...
+    memset(pSym, 0, sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN);
+    pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+    pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
+
+    memset(&Line, 0, sizeof(Line));
+    Line.SizeOfStruct = sizeof(Line);
+
+    memset(&Module, 0, sizeof(Module));
+    Module.SizeOfStruct = sizeof(Module);
+
+    for (frameNum = 0;; ++frameNum)
+    {
+        // get next stack frame (StackWalk64(), SymFunctionTableAccess64(), SymGetModuleBase64())
+        // if this returns ERROR_INVALID_ADDRESS (487) or ERROR_NOACCESS (998), you can
+        // assume that either you are done, or that the stack is so hosed that the next
+        // deeper frame could not be found.
+        // CONTEXT need not to be supplied if imageTyp is IMAGE_FILE_MACHINE_I386!
+        if (!this->m_sw->pSW(imageType, this->m_hProcess, hThread, &s, &c, myReadProcMem, this->m_sw->pSFTA, this->m_sw->pSGMB, NULL))
+        {
+            // INFO: "StackWalk64" does not set "GetLastError"...
+            this->OnDbgHelpErr("StackWalk64", 0, s.AddrPC.Offset);
+            break;
+        }
+
+        csEntry.offset = s.AddrPC.Offset;
+        csEntry.name[0] = 0;
+        csEntry.undName[0] = 0;
+        csEntry.undFullName[0] = 0;
+        csEntry.offsetFromSmybol = 0;
+        csEntry.offsetFromLine = 0;
+        csEntry.lineFileName[0] = 0;
+        csEntry.lineNumber = 0;
+        csEntry.loadedImageName[0] = 0;
+        csEntry.moduleName[0] = 0;
+        if (s.AddrPC.Offset == s.AddrReturn.Offset)
+        {
+            if ((this->m_MaxRecursionCount > 0) && (curRecursionCount > m_MaxRecursionCount))
+            {
+                this->OnDbgHelpErr("StackWalk64-Endless-Callstack!", 0, s.AddrPC.Offset);
+                break;
+            }
+            curRecursionCount++;
+        }
+        else
+            curRecursionCount = 0;
+        if (s.AddrPC.Offset != 0)
+        {
+            // we seem to have a valid PC
+            // show procedure info (SymGetSymFromAddr64())
+            if (this->m_sw->pSGSFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromSmybol), pSym) != FALSE)
+            {
+                MyStrCpy(csEntry.name, STACKWALK_MAX_NAMELEN, pSym->Name);
+                // UnDecorateSymbolName()
+                this->m_sw->pUDSN(pSym->Name, csEntry.undName, STACKWALK_MAX_NAMELEN, UNDNAME_NAME_ONLY);
+                this->m_sw->pUDSN(pSym->Name, csEntry.undFullName, STACKWALK_MAX_NAMELEN, UNDNAME_COMPLETE);
+            }
+            else
+            {
+                this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), s.AddrPC.Offset);
+            }
+
+            // show line number info, NT5.0-method (SymGetLineFromAddr64())
+            if (this->m_sw->pSGLFA != NULL)
+            { // yes, we have SymGetLineFromAddr64()
+                if (this->m_sw->pSGLFA(this->m_hProcess, s.AddrPC.Offset, &(csEntry.offsetFromLine), &Line) != FALSE)
+                {
+                    csEntry.lineNumber = Line.LineNumber;
+                    MyStrCpy(csEntry.lineFileName, STACKWALK_MAX_NAMELEN, Line.FileName);
+                }
+                else
+                {
+                    this->OnDbgHelpErr("SymGetLineFromAddr64", GetLastError(), s.AddrPC.Offset);
+                }
+            } // yes, we have SymGetLineFromAddr64()
+
+            // show module info (SymGetModuleInfo64())
+            if (this->m_sw->GetModuleInfo(this->m_hProcess, s.AddrPC.Offset, &Module) != FALSE)
+            { // got module info OK
+                switch (Module.SymType)
+                {
+                case SymNone:
+                    csEntry.symTypeString = "-nosymbols-";
+                    break;
+                case SymCoff:
+                    csEntry.symTypeString = "COFF";
+                    break;
+                case SymCv:
+                    csEntry.symTypeString = "CV";
+                    break;
+                case SymPdb:
+                    csEntry.symTypeString = "PDB";
+                    break;
+                case SymExport:
+                    csEntry.symTypeString = "-exported-";
+                    break;
+                case SymDeferred:
+                    csEntry.symTypeString = "-deferred-";
+                    break;
+                case SymSym:
+                    csEntry.symTypeString = "SYM";
+                    break;
+#if API_VERSION_NUMBER >= 9
+                case SymDia:
+                    csEntry.symTypeString = "DIA";
+                    break;
+#endif
+                case 8: // SymVirtual:
+                    csEntry.symTypeString = "Virtual";
+                    break;
+                default:
+                    //_snprintf( ty, sizeof(ty), "symtype=%ld", (long) Module.SymType );
+                    csEntry.symTypeString = NULL;
+                    break;
+                }
+
+                MyStrCpy(csEntry.moduleName, STACKWALK_MAX_NAMELEN, Module.ModuleName);
+                csEntry.baseOfImage = Module.BaseOfImage;
+                MyStrCpy(csEntry.loadedImageName, STACKWALK_MAX_NAMELEN, Module.LoadedImageName);
+            } // got module info OK
+            else
+            {
+                this->OnDbgHelpErr("SymGetModuleInfo64", GetLastError(), s.AddrPC.Offset);
+            }
+        } // we seem to have a valid PC
+
+        CallstackEntryType et = nextEntry;
+        if (frameNum == 0)
+            et = firstEntry;
+        bLastEntryCalled = false;
+        this->OnCallstackEntry(et, csEntry);
+
+        if (s.AddrReturn.Offset == 0)
+        {
+            bLastEntryCalled = true;
+            this->OnCallstackEntry(lastEntry, csEntry);
+            SetLastError(ERROR_SUCCESS);
+            break;
+        }
+    } // for ( frameNum )
+
+cleanup:
+    if (pSym)
+        free(pSym);
+
+    if (bLastEntryCalled == false)
+        this->OnCallstackEntry(lastEntry, csEntry);
+
+    if (context == NULL)
+        ResumeThread(hThread);
+
+    return TRUE;
+}
+
+BOOL StackWalker::ShowObject(LPVOID pObject)
+{
+    // Load modules if not done yet
+    if (m_modulesLoaded == FALSE)
+        this->LoadModules(); // ignore the result...
+
+    // Verify that the DebugHelp.dll was actually found
+    if (this->m_sw->m_hDbhHelp == NULL)
+    {
+        SetLastError(ERROR_DLL_INIT_FAILED);
+        return FALSE;
+    }
+
+    // SymGetSymFromAddr64() is required
+    if (this->m_sw->pSGSFA == NULL)
+        return FALSE;
+
+    // Show object info (SymGetSymFromAddr64())
+    DWORD64 dwAddress = DWORD64(pObject);
+    DWORD64 dwDisplacement = 0;
+    const SIZE_T symSize = sizeof(IMAGEHLP_SYMBOL64) + STACKWALK_MAX_NAMELEN;
+    IMAGEHLP_SYMBOL64* pSym = (IMAGEHLP_SYMBOL64*)malloc(symSize);
+    if (!pSym)
+        return FALSE;
+    memset(pSym, 0, symSize);
+    pSym->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+    pSym->MaxNameLength = STACKWALK_MAX_NAMELEN;
+    if (this->m_sw->pSGSFA(this->m_hProcess, dwAddress, &dwDisplacement, pSym) == FALSE)
+    {
+        this->OnDbgHelpErr("SymGetSymFromAddr64", GetLastError(), dwAddress);
+        return FALSE;
+    }
+    // Object name output
+    this->OnOutput(pSym->Name);
+
+    free(pSym);
+    return TRUE;
+};
+
+BOOL __stdcall StackWalker::myReadProcMem(HANDLE hProcess, DWORD64 qwBaseAddress, PVOID lpBuffer, DWORD nSize, LPDWORD lpNumberOfBytesRead)
+{
+    if (s_readMemoryFunction == NULL)
+    {
+        SIZE_T st;
+        BOOL bRet = ReadProcessMemory(hProcess, (LPVOID)qwBaseAddress, lpBuffer, nSize, &st);
+        *lpNumberOfBytesRead = (DWORD)st;
+        // printf("ReadMemory: hProcess: %p, baseAddr: %p, buffer: %p, size: %d, read: %d, result: %d\n", hProcess, (LPVOID) qwBaseAddress, lpBuffer, nSize, (DWORD) st, (DWORD) bRet);
+        return bRet;
+    }
+    else
+    {
+        return s_readMemoryFunction(hProcess, qwBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead, s_readMemoryFunction_UserData);
+    }
+}
+
+void StackWalker::OnLoadModule(LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size, DWORD result, LPCSTR symType, LPCSTR pdbName, ULONGLONG fileVersion)
+{
+    CHAR buffer[STACKWALK_MAX_NAMELEN];
+    size_t maxLen = STACKWALK_MAX_NAMELEN;
+#if _MSC_VER >= 1400
+    maxLen = _TRUNCATE;
+#endif
+    if (fileVersion == 0)
+        _snprintf_s(buffer, maxLen, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s'\n", img, mod, (LPVOID)baseAddr, size, result, symType, pdbName);
+    else
+    {
+        DWORD v4 = (DWORD)(fileVersion & 0xFFFF);
+        DWORD v3 = (DWORD)((fileVersion >> 16) & 0xFFFF);
+        DWORD v2 = (DWORD)((fileVersion >> 32) & 0xFFFF);
+        DWORD v1 = (DWORD)((fileVersion >> 48) & 0xFFFF);
+        _snprintf_s(buffer, maxLen, "%s:%s (%p), size: %d (result: %d), SymType: '%s', PDB: '%s', fileVersion: %d.%d.%d.%d\n", img, mod,
+                    (LPVOID)baseAddr, size, result, symType, pdbName, v1, v2, v3, v4);
+    }
+    buffer[STACKWALK_MAX_NAMELEN - 1] = 0; // be sure it is NULL terminated
+    OnOutput(buffer);
+}
+
+void StackWalker::OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry)
+{
+    CHAR buffer[STACKWALK_MAX_NAMELEN];
+    size_t maxLen = STACKWALK_MAX_NAMELEN;
+#if _MSC_VER >= 1400
+    maxLen = _TRUNCATE;
+#endif
+    if ((eType != lastEntry) && (entry.offset != 0))
+    {
+        if (entry.name[0] == 0)
+            MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, "(function-name not available)");
+        if (entry.undName[0] != 0)
+            MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undName);
+        if (entry.undFullName[0] != 0)
+            MyStrCpy(entry.name, STACKWALK_MAX_NAMELEN, entry.undFullName);
+        if (entry.lineFileName[0] == 0)
+        {
+            MyStrCpy(entry.lineFileName, STACKWALK_MAX_NAMELEN, "(filename not available)");
+            if (entry.moduleName[0] == 0)
+                MyStrCpy(entry.moduleName, STACKWALK_MAX_NAMELEN, "(module-name not available)");
+            _snprintf_s(buffer, maxLen, "%p (%s): %s: %s\n", (LPVOID)entry.offset, entry.moduleName, entry.lineFileName, entry.name);
+        }
+        else
+            _snprintf_s(buffer, maxLen, "%s (%d): %s\n", entry.lineFileName, entry.lineNumber, entry.name);
+        buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+        OnOutput(buffer);
+    }
+}
+
+void StackWalker::OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr)
+{
+    CHAR buffer[STACKWALK_MAX_NAMELEN];
+    size_t maxLen = STACKWALK_MAX_NAMELEN;
+#if _MSC_VER >= 1400
+    maxLen = _TRUNCATE;
+#endif
+    _snprintf_s(buffer, maxLen, "ERROR: %s, GetLastError: %d (Address: %p)\n", szFuncName, gle, (LPVOID)addr);
+    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+    OnOutput(buffer);
+}
+
+void StackWalker::OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName)
+{
+    CHAR buffer[STACKWALK_MAX_NAMELEN];
+    size_t maxLen = STACKWALK_MAX_NAMELEN;
+#if _MSC_VER >= 1400
+    maxLen = _TRUNCATE;
+#endif
+    _snprintf_s(buffer, maxLen, "SymInit: Symbol-SearchPath: '%s', symOptions: %d, UserName: '%s'\n", szSearchPath, symOptions, szUserName);
+    buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+    OnOutput(buffer);
+    // Also display the OS-version
+#if _MSC_VER <= 1200
+    OSVERSIONINFOA ver;
+    ZeroMemory(&ver, sizeof(OSVERSIONINFOA));
+    ver.dwOSVersionInfoSize = sizeof(ver);
+    if (GetVersionExA(&ver) != FALSE)
+    {
+        _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s)\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber, ver.szCSDVersion);
+        buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+        OnOutput(buffer);
+    }
+#else
+    OSVERSIONINFOEXA ver;
+    ZeroMemory(&ver, sizeof(OSVERSIONINFOEXA));
+    ver.dwOSVersionInfoSize = sizeof(ver);
+#if _MSC_VER >= 1900
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+    if (GetVersionExA((OSVERSIONINFOA*)&ver) != FALSE)
+    {
+        _snprintf_s(buffer, maxLen, "OS-Version: %d.%d.%d (%s) 0x%x-0x%x\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber,
+                    ver.szCSDVersion, ver.wSuiteMask, ver.wProductType);
+        buffer[STACKWALK_MAX_NAMELEN - 1] = 0;
+        OnOutput(buffer);
+    }
+#if _MSC_VER >= 1900
+#pragma warning(pop)
+#endif
+#endif
+}
+
+void StackWalker::OnOutput(LPCSTR buffer) { OutputDebugStringA(buffer); }
+#endif

--- a/src/clean-core/detail/lib/StackWalker.cc
+++ b/src/clean-core/detail/lib/StackWalker.cc
@@ -287,7 +287,7 @@ public:
         if (GetModuleFileName(NULL, szTemp, 4096) > 0)
         {
             _tcscat_s(szTemp, _T(".local"));
-            if (GetFileAttributes(szTemp) == INVALID_FILE_ATTRIBUTES)
+            if (GetFileAttributesA(szTemp) == INVALID_FILE_ATTRIBUTES)
             {
                 // ".local" file does not exist, so we can try to load the dbghelp.dll from the "Debugging Tools for Windows"
                 // Ok, first try the new path according to the architecture:
@@ -302,11 +302,11 @@ public:
                     }
                 }
 #elif _M_X64
-                if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+                if ((m_hDbhHelp == NULL) && (GetEnvironmentVariableA(_T("ProgramFiles"), szTemp, 4096) > 0))
                 {
                     _tcscat_s(szTemp, _T("\\Debugging Tools for Windows (x64)\\dbghelp.dll"));
                     // now check if the file exists:
-                    if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+                    if (GetFileAttributesA(szTemp) != INVALID_FILE_ATTRIBUTES)
                     {
                         m_hDbhHelp = LoadLibrary(szTemp);
                     }
@@ -323,21 +323,21 @@ public:
                 }
 #endif
                 // If still not found, try the old directories...
-                if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+                if ((m_hDbhHelp == NULL) && (GetEnvironmentVariableA(_T("ProgramFiles"), szTemp, 4096) > 0))
                 {
                     _tcscat_s(szTemp, _T("\\Debugging Tools for Windows\\dbghelp.dll"));
                     // now check if the file exists:
-                    if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+                    if (GetFileAttributesA(szTemp) != INVALID_FILE_ATTRIBUTES)
                     {
                         m_hDbhHelp = LoadLibrary(szTemp);
                     }
                 }
 #if defined _M_X64 || defined _M_IA64
                 // Still not found? Then try to load the (old) 64-Bit version:
-                if ((m_hDbhHelp == NULL) && (GetEnvironmentVariable(_T("ProgramFiles"), szTemp, 4096) > 0))
+                if ((m_hDbhHelp == NULL) && (GetEnvironmentVariableA(_T("ProgramFiles"), szTemp, 4096) > 0))
                 {
                     _tcscat_s(szTemp, _T("\\Debugging Tools for Windows 64-Bit\\dbghelp.dll"));
-                    if (GetFileAttributes(szTemp) != INVALID_FILE_ATTRIBUTES)
+                    if (GetFileAttributesA(szTemp) != INVALID_FILE_ATTRIBUTES)
                     {
                         m_hDbhHelp = LoadLibrary(szTemp);
                     }

--- a/src/clean-core/detail/lib/StackWalker.hh
+++ b/src/clean-core/detail/lib/StackWalker.hh
@@ -45,7 +45,7 @@
 // so we need not to check the version (because we only support _MSC_VER >= 1100)!
 #pragma once
 
-#include <windows.h>
+#include <clean-core/native/win32_sanitized.hh>
 
 #if _MSC_VER >= 1900
 #pragma warning(disable : 4091)

--- a/src/clean-core/detail/lib/StackWalker.hh
+++ b/src/clean-core/detail/lib/StackWalker.hh
@@ -1,0 +1,247 @@
+#pragma once
+
+#ifdef _WIN32
+
+#ifndef __STACKWALKER_H__
+#define __STACKWALKER_H__
+
+#if defined(_MSC_VER)
+
+/**********************************************************************
+ *
+ * StackWalker.h
+ *
+ *
+ *
+ * LICENSE (http://www.opensource.org/licenses/bsd-license.php)
+ *
+ *   Copyright (c) 2005-2009, Jochen Kalmbach
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *   Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *   Neither the name of Jochen Kalmbach nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * **********************************************************************/
+// #pragma once is supported starting with _MSC_VER 1000,
+// so we need not to check the version (because we only support _MSC_VER >= 1100)!
+#pragma once
+
+#include <windows.h>
+
+#if _MSC_VER >= 1900
+#pragma warning(disable : 4091)
+#endif
+
+// special defines for VC5/6 (if no actual PSDK is installed):
+#if _MSC_VER < 1300
+typedef unsigned __int64 DWORD64, *PDWORD64;
+#if defined(_WIN64)
+typedef unsigned __int64 SIZE_T, *PSIZE_T;
+#else
+typedef unsigned long SIZE_T, *PSIZE_T;
+#endif
+#endif // _MSC_VER < 1300
+
+class StackWalkerInternal; // forward
+class StackWalker
+{
+public:
+    typedef enum StackWalkOptions
+    {
+        // No addition info will be retrieved
+        // (only the address is available)
+        RetrieveNone = 0,
+
+        // Try to get the symbol-name
+        RetrieveSymbol = 1,
+
+        // Try to get the line for this symbol
+        RetrieveLine = 2,
+
+        // Try to retrieve the module-infos
+        RetrieveModuleInfo = 4,
+
+        // Also retrieve the version for the DLL/EXE
+        RetrieveFileVersion = 8,
+
+        // Contains all the above
+        RetrieveVerbose = 0xF,
+
+        // Generate a "good" symbol-search-path
+        SymBuildPath = 0x10,
+
+        // Also use the public Microsoft-Symbol-Server
+        SymUseSymSrv = 0x20,
+
+        // Contains all the above "Sym"-options
+        SymAll = 0x30,
+
+        // Contains all options (default)
+        OptionsAll = 0x3F
+    } StackWalkOptions;
+
+    StackWalker(int options = OptionsAll, // 'int' is by design, to combine the enum-flags
+                LPCSTR szSymPath = NULL,
+                DWORD dwProcessId = GetCurrentProcessId(),
+                HANDLE hProcess = GetCurrentProcess());
+    StackWalker(DWORD dwProcessId, HANDLE hProcess);
+    virtual ~StackWalker();
+
+    typedef BOOL(__stdcall* PReadProcessMemoryRoutine)(HANDLE hProcess,
+                                                       DWORD64 qwBaseAddress,
+                                                       PVOID lpBuffer,
+                                                       DWORD nSize,
+                                                       LPDWORD lpNumberOfBytesRead,
+                                                       LPVOID pUserData // optional data, which was passed in "ShowCallstack"
+    );
+
+    BOOL LoadModules();
+
+    BOOL ShowCallstack(HANDLE hThread = GetCurrentThread(),
+                       const CONTEXT* context = NULL,
+                       PReadProcessMemoryRoutine readMemoryFunction = NULL,
+                       LPVOID pUserData = NULL // optional to identify some data in the 'readMemoryFunction'-callback
+    );
+
+    BOOL ShowObject(LPVOID pObject);
+
+#if _MSC_VER >= 1300
+    // due to some reasons, the "STACKWALK_MAX_NAMELEN" must be declared as "public"
+    // in older compilers in order to use it... starting with VC7 we can declare it as "protected"
+protected:
+#endif
+    enum
+    {
+        STACKWALK_MAX_NAMELEN = 1024
+    }; // max name length for found symbols
+
+protected:
+    // Entry for each Callstack-Entry
+    typedef struct CallstackEntry
+    {
+        DWORD64 offset; // if 0, we have no valid entry
+        CHAR name[STACKWALK_MAX_NAMELEN];
+        CHAR undName[STACKWALK_MAX_NAMELEN];
+        CHAR undFullName[STACKWALK_MAX_NAMELEN];
+        DWORD64 offsetFromSmybol;
+        DWORD offsetFromLine;
+        DWORD lineNumber;
+        CHAR lineFileName[STACKWALK_MAX_NAMELEN];
+        DWORD symType;
+        LPCSTR symTypeString;
+        CHAR moduleName[STACKWALK_MAX_NAMELEN];
+        DWORD64 baseOfImage;
+        CHAR loadedImageName[STACKWALK_MAX_NAMELEN];
+    } CallstackEntry;
+
+    typedef enum CallstackEntryType
+    {
+        firstEntry,
+        nextEntry,
+        lastEntry
+    } CallstackEntryType;
+
+    virtual void OnSymInit(LPCSTR szSearchPath, DWORD symOptions, LPCSTR szUserName);
+    virtual void OnLoadModule(LPCSTR img, LPCSTR mod, DWORD64 baseAddr, DWORD size, DWORD result, LPCSTR symType, LPCSTR pdbName, ULONGLONG fileVersion);
+    virtual void OnCallstackEntry(CallstackEntryType eType, CallstackEntry& entry);
+    virtual void OnDbgHelpErr(LPCSTR szFuncName, DWORD gle, DWORD64 addr);
+    virtual void OnOutput(LPCSTR szText);
+
+    StackWalkerInternal* m_sw;
+    HANDLE m_hProcess;
+    DWORD m_dwProcessId;
+    BOOL m_modulesLoaded;
+    LPSTR m_szSymPath;
+
+    int m_options;
+    int m_MaxRecursionCount;
+
+    static BOOL __stdcall myReadProcMem(HANDLE hProcess, DWORD64 qwBaseAddress, PVOID lpBuffer, DWORD nSize, LPDWORD lpNumberOfBytesRead);
+
+    friend StackWalkerInternal;
+}; // class StackWalker
+
+// The "ugly" assembler-implementation is needed for systems before XP
+// If you have a new PSDK and you only compile for XP and later, then you can use
+// the "RtlCaptureContext"
+// Currently there is no define which determines the PSDK-Version...
+// So we just use the compiler-version (and assumes that the PSDK is
+// the one which was installed by the VS-IDE)
+
+// INFO: If you want, you can use the RtlCaptureContext if you only target XP and later...
+//       But I currently use it in x64/IA64 environments...
+//#if defined(_M_IX86) && (_WIN32_WINNT <= 0x0500) && (_MSC_VER < 1400)
+
+#if defined(_M_IX86)
+#ifdef CURRENT_THREAD_VIA_EXCEPTION
+// TODO: The following is not a "good" implementation,
+// because the callstack is only valid in the "__except" block...
+#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags)                                               \
+    do                                                                                                          \
+    {                                                                                                           \
+        memset(&c, 0, sizeof(CONTEXT));                                                                         \
+        EXCEPTION_POINTERS* pExp = NULL;                                                                        \
+        __try                                                                                                   \
+        {                                                                                                       \
+            throw 0;                                                                                            \
+        }                                                                                                       \
+        __except (((pExp = GetExceptionInformation()) ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_EXECUTE_HANDLER)) \
+        {                                                                                                       \
+        }                                                                                                       \
+        if (pExp != NULL)                                                                                       \
+            memcpy(&c, pExp->ContextRecord, sizeof(CONTEXT));                                                   \
+        c.ContextFlags = contextFlags;                                                                          \
+    } while (0);
+#else
+// clang-format off
+// The following should be enough for walking the callstack...
+#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
+  do                                                              \
+  {                                                               \
+    memset(&c, 0, sizeof(CONTEXT));                               \
+    c.ContextFlags = contextFlags;                                \
+    __asm    call x                                               \
+    __asm x: pop eax                                              \
+    __asm    mov c.Eip, eax                                       \
+    __asm    mov c.Ebp, ebp                                       \
+    __asm    mov c.Esp, esp                                       \
+  } while (0)
+// clang-format on
+#endif
+
+#else
+
+// The following is defined for x86 (XP and higher), x64 and IA64:
+#define GET_CURRENT_CONTEXT_STACKWALKER_CODEPLEX(c, contextFlags) \
+    do                                                            \
+    {                                                             \
+        memset(&c, 0, sizeof(CONTEXT));                           \
+        c.ContextFlags = contextFlags;                            \
+        RtlCaptureContext(&c);                                    \
+    } while (0);
+#endif
+
+#endif // defined(_MSC_VER)
+
+#endif // __STACKWALKER_H__
+
+#endif // ifdef WIN32

--- a/src/clean-core/detail/lib/tlsf.cc
+++ b/src/clean-core/detail/lib/tlsf.cc
@@ -1,0 +1,1201 @@
+#include <assert.h>
+#include <limits.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tlsf.hh"
+
+#if defined(__cplusplus)
+#define tlsf_decl inline
+#else
+#define tlsf_decl static
+#endif
+
+/*
+** Architecture-specific bit manipulation routines.
+**
+** TLSF achieves O(1) cost for malloc and free operations by limiting
+** the search for a free block to a free list of guaranteed size
+** adequate to fulfill the request, combined with efficient free list
+** queries using bitmasks and architecture-specific bit-manipulation
+** routines.
+**
+** Most modern processors provide instructions to count leading zeroes
+** in a word, find the lowest and highest set bit, etc. These
+** specific implementations will be used when available, falling back
+** to a reasonably efficient generic implementation.
+**
+** NOTE: TLSF spec relies on ffs/fls returning value 0..31.
+** ffs/fls return 1-32 by default, returning 0 for error.
+*/
+
+/*
+** Detect whether or not we are building for a 32- or 64-bit (LP/LLP)
+** architecture. There is no reliable portable method at compile-time.
+*/
+#if defined(__alpha__) || defined(__ia64__) || defined(__x86_64__) || defined(_WIN64) || defined(__LP64__) || defined(__LLP64__)
+#define TLSF_64BIT
+#endif
+
+/*
+** gcc 3.4 and above have builtin support, specialized for architecture.
+** Some compilers masquerade as gcc; patchlevel test filters them out.
+*/
+#if defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)) && defined(__GNUC_PATCHLEVEL__)
+
+#if defined(__SNC__)
+/* SNC for Playstation 3. */
+
+tlsf_decl int tlsf_ffs(unsigned int word)
+{
+    const unsigned int reverse = word & (~word + 1);
+    const int bit = 32 - __builtin_clz(reverse);
+    return bit - 1;
+}
+
+#else
+
+tlsf_decl int tlsf_ffs(unsigned int word) { return __builtin_ffs(word) - 1; }
+
+#endif
+
+tlsf_decl int tlsf_fls(unsigned int word)
+{
+    const int bit = word ? 32 - __builtin_clz(word) : 0;
+    return bit - 1;
+}
+
+#elif defined(_MSC_VER) && (_MSC_VER >= 1400) && (defined(_M_IX86) || defined(_M_X64))
+/* Microsoft Visual C++ support on x86/X64 architectures. */
+
+#include <intrin.h>
+
+#pragma intrinsic(_BitScanReverse)
+#pragma intrinsic(_BitScanForward)
+
+tlsf_decl int tlsf_fls(unsigned int word)
+{
+    unsigned long index;
+    return _BitScanReverse(&index, word) ? index : -1;
+}
+
+tlsf_decl int tlsf_ffs(unsigned int word)
+{
+    unsigned long index;
+    return _BitScanForward(&index, word) ? index : -1;
+}
+
+#elif defined(_MSC_VER) && defined(_M_PPC)
+/* Microsoft Visual C++ support on PowerPC architectures. */
+
+#include <ppcintrinsics.h>
+
+tlsf_decl int tlsf_fls(unsigned int word)
+{
+    const int bit = 32 - _CountLeadingZeros(word);
+    return bit - 1;
+}
+
+tlsf_decl int tlsf_ffs(unsigned int word)
+{
+    const unsigned int reverse = word & (~word + 1);
+    const int bit = 32 - _CountLeadingZeros(reverse);
+    return bit - 1;
+}
+
+#elif defined(__ARMCC_VERSION)
+/* RealView Compilation Tools for ARM */
+
+tlsf_decl int tlsf_ffs(unsigned int word)
+{
+    const unsigned int reverse = word & (~word + 1);
+    const int bit = 32 - __clz(reverse);
+    return bit - 1;
+}
+
+tlsf_decl int tlsf_fls(unsigned int word)
+{
+    const int bit = word ? 32 - __clz(word) : 0;
+    return bit - 1;
+}
+
+#elif defined(__ghs__)
+/* Green Hills support for PowerPC */
+
+#include <ppc_ghs.h>
+
+tlsf_decl int tlsf_ffs(unsigned int word)
+{
+    const unsigned int reverse = word & (~word + 1);
+    const int bit = 32 - __CLZ32(reverse);
+    return bit - 1;
+}
+
+tlsf_decl int tlsf_fls(unsigned int word)
+{
+    const int bit = word ? 32 - __CLZ32(word) : 0;
+    return bit - 1;
+}
+
+#else
+/* Fall back to generic implementation. */
+
+tlsf_decl int tlsf_fls_generic(unsigned int word)
+{
+    int bit = 32;
+
+    if (!word)
+        bit -= 1;
+    if (!(word & 0xffff0000))
+    {
+        word <<= 16;
+        bit -= 16;
+    }
+    if (!(word & 0xff000000))
+    {
+        word <<= 8;
+        bit -= 8;
+    }
+    if (!(word & 0xf0000000))
+    {
+        word <<= 4;
+        bit -= 4;
+    }
+    if (!(word & 0xc0000000))
+    {
+        word <<= 2;
+        bit -= 2;
+    }
+    if (!(word & 0x80000000))
+    {
+        word <<= 1;
+        bit -= 1;
+    }
+
+    return bit;
+}
+
+/* Implement ffs in terms of fls. */
+tlsf_decl int tlsf_ffs(unsigned int word) { return tlsf_fls_generic(word & (~word + 1)) - 1; }
+
+tlsf_decl int tlsf_fls(unsigned int word) { return tlsf_fls_generic(word) - 1; }
+
+#endif
+
+/* Possibly 64-bit version of tlsf_fls. */
+#if defined(TLSF_64BIT)
+tlsf_decl int tlsf_fls_sizet(size_t size)
+{
+    int high = (int)(size >> 32);
+    int bits = 0;
+    if (high)
+    {
+        bits = 32 + tlsf_fls(high);
+    }
+    else
+    {
+        bits = tlsf_fls((int)size & 0xffffffff);
+    }
+    return bits;
+}
+#else
+#define tlsf_fls_sizet tlsf_fls
+#endif
+
+#undef tlsf_decl
+
+/*
+** Constants.
+*/
+
+/* Public constants: may be modified. */
+enum tlsf_public
+{
+    /* log2 of number of linear subdivisions of block sizes. Larger
+    ** values require more memory in the control structure. Values of
+    ** 4 or 5 are typical.
+    */
+    SL_INDEX_COUNT_LOG2 = 5,
+};
+
+/* Private constants: do not modify. */
+enum tlsf_private
+{
+#if defined(TLSF_64BIT)
+    /* All allocation sizes and addresses are aligned to 8 bytes. */
+    ALIGN_SIZE_LOG2 = 3,
+#else
+    /* All allocation sizes and addresses are aligned to 4 bytes. */
+    ALIGN_SIZE_LOG2 = 2,
+#endif
+    ALIGN_SIZE = (1 << ALIGN_SIZE_LOG2),
+
+/*
+** We support allocations of sizes up to (1 << FL_INDEX_MAX) bits.
+** However, because we linearly subdivide the second-level lists, and
+** our minimum size granularity is 4 bytes, it doesn't make sense to
+** create first-level lists for sizes smaller than SL_INDEX_COUNT * 4,
+** or (1 << (SL_INDEX_COUNT_LOG2 + 2)) bytes, as there we will be
+** trying to split size ranges into more slots than we have available.
+** Instead, we calculate the minimum threshold size, and place all
+** blocks below that size into the 0th first-level list.
+*/
+
+#if defined(TLSF_64BIT)
+    /*
+    ** TODO: We can increase this to support larger sizes, at the expense
+    ** of more overhead in the TLSF structure.
+    */
+    FL_INDEX_MAX = 32,
+#else
+    FL_INDEX_MAX = 30,
+#endif
+    SL_INDEX_COUNT = (1 << SL_INDEX_COUNT_LOG2),
+    FL_INDEX_SHIFT = (SL_INDEX_COUNT_LOG2 + ALIGN_SIZE_LOG2),
+    FL_INDEX_COUNT = (FL_INDEX_MAX - FL_INDEX_SHIFT + 1),
+
+    SMALL_BLOCK_SIZE = (1 << FL_INDEX_SHIFT),
+};
+
+/*
+** Cast and min/max macros.
+*/
+
+#define tlsf_cast(t, exp) ((t)(exp))
+#define tlsf_min(a, b) ((a) < (b) ? (a) : (b))
+#define tlsf_max(a, b) ((a) > (b) ? (a) : (b))
+
+/*
+** Set assert macro, if it has not been provided by the user.
+*/
+#if !defined(tlsf_assert)
+#define tlsf_assert assert
+#endif
+
+/*
+** Static assertion mechanism.
+*/
+
+#define _tlsf_glue2(x, y) x##y
+#define _tlsf_glue(x, y) _tlsf_glue2(x, y)
+#define tlsf_static_assert(exp) typedef char _tlsf_glue(static_assert, __LINE__)[(exp) ? 1 : -1]
+
+/* This code has been tested on 32- and 64-bit (LP/LLP) architectures. */
+tlsf_static_assert(sizeof(int) * CHAR_BIT == 32);
+tlsf_static_assert(sizeof(size_t) * CHAR_BIT >= 32);
+tlsf_static_assert(sizeof(size_t) * CHAR_BIT <= 64);
+
+/* SL_INDEX_COUNT must be <= number of bits in sl_bitmap's storage type. */
+tlsf_static_assert(sizeof(unsigned int) * CHAR_BIT >= SL_INDEX_COUNT);
+
+/* Ensure we've properly tuned our sizes. */
+tlsf_static_assert(ALIGN_SIZE == SMALL_BLOCK_SIZE / SL_INDEX_COUNT);
+
+/*
+** Data structures and associated constants.
+*/
+
+/*
+** Block header structure.
+**
+** There are several implementation subtleties involved:
+** - The prev_phys_block field is only valid if the previous block is free.
+** - The prev_phys_block field is actually stored at the end of the
+**   previous block. It appears at the beginning of this structure only to
+**   simplify the implementation.
+** - The next_free / prev_free fields are only valid if the block is free.
+*/
+typedef struct block_header_t
+{
+    /* Points to the previous physical block. */
+    struct block_header_t* prev_phys_block;
+
+    /* The size of this block, excluding the block header. */
+    size_t size;
+
+    /* Next and previous free blocks. */
+    struct block_header_t* next_free;
+    struct block_header_t* prev_free;
+} block_header_t;
+
+/*
+** Since block sizes are always at least a multiple of 4, the two least
+** significant bits of the size field are used to store the block status:
+** - bit 0: whether block is busy or free
+** - bit 1: whether previous block is busy or free
+*/
+static const size_t block_header_free_bit = 1 << 0;
+static const size_t block_header_prev_free_bit = 1 << 1;
+
+/*
+** The size of the block header exposed to used blocks is the size field.
+** The prev_phys_block field is stored *inside* the previous free block.
+*/
+static const size_t block_header_overhead = sizeof(size_t);
+
+/* User data starts directly after the size field in a used block. */
+static const size_t block_start_offset = offsetof(block_header_t, size) + sizeof(size_t);
+
+/*
+** A free block must be large enough to store its header minus the size of
+** the prev_phys_block field, and no larger than the number of addressable
+** bits for FL_INDEX.
+*/
+static const size_t block_size_min = sizeof(block_header_t) - sizeof(block_header_t*);
+static const size_t block_size_max = tlsf_cast(size_t, 1) << FL_INDEX_MAX;
+
+
+/* The TLSF control structure. */
+typedef struct control_t
+{
+    /* Empty lists point at this block to indicate they are free. */
+    block_header_t block_null;
+
+    /* Bitmaps for free lists. */
+    unsigned int fl_bitmap;
+    unsigned int sl_bitmap[FL_INDEX_COUNT];
+
+    /* Head of free lists. */
+    block_header_t* blocks[FL_INDEX_COUNT][SL_INDEX_COUNT];
+} control_t;
+
+/* A type used for casting when doing pointer arithmetic. */
+typedef ptrdiff_t tlsfptr_t;
+
+/*
+** block_header_t member functions.
+*/
+
+static size_t block_size(const block_header_t* block) { return block->size & ~(block_header_free_bit | block_header_prev_free_bit); }
+
+static void block_set_size(block_header_t* block, size_t size)
+{
+    const size_t oldsize = block->size;
+    block->size = size | (oldsize & (block_header_free_bit | block_header_prev_free_bit));
+}
+
+static int block_is_last(const block_header_t* block) { return block_size(block) == 0; }
+
+static int block_is_free(const block_header_t* block) { return tlsf_cast(int, block->size& block_header_free_bit); }
+
+static void block_set_free(block_header_t* block) { block->size |= block_header_free_bit; }
+
+static void block_set_used(block_header_t* block) { block->size &= ~block_header_free_bit; }
+
+static int block_is_prev_free(const block_header_t* block) { return tlsf_cast(int, block->size& block_header_prev_free_bit); }
+
+static void block_set_prev_free(block_header_t* block) { block->size |= block_header_prev_free_bit; }
+
+static void block_set_prev_used(block_header_t* block) { block->size &= ~block_header_prev_free_bit; }
+
+static block_header_t* block_from_ptr(const void* ptr) { return tlsf_cast(block_header_t*, tlsf_cast(unsigned char*, ptr) - block_start_offset); }
+
+static void* block_to_ptr(const block_header_t* block) { return tlsf_cast(void*, tlsf_cast(unsigned char*, block) + block_start_offset); }
+
+/* Return location of next block after block of given size. */
+static block_header_t* offset_to_block(const void* ptr, size_t size) { return tlsf_cast(block_header_t*, tlsf_cast(tlsfptr_t, ptr) + size); }
+
+/* Return location of previous block. */
+static block_header_t* block_prev(const block_header_t* block)
+{
+    tlsf_assert(block_is_prev_free(block) && "previous block must be free");
+    return block->prev_phys_block;
+}
+
+/* Return location of next existing block. */
+static block_header_t* block_next(const block_header_t* block)
+{
+    block_header_t* next = offset_to_block(block_to_ptr(block), block_size(block) - block_header_overhead);
+    tlsf_assert(!block_is_last(block));
+    return next;
+}
+
+/* Link a new block with its physical neighbor, return the neighbor. */
+static block_header_t* block_link_next(block_header_t* block)
+{
+    block_header_t* next = block_next(block);
+    next->prev_phys_block = block;
+    return next;
+}
+
+static void block_mark_as_free(block_header_t* block)
+{
+    /* Link the block to the next block, first. */
+    block_header_t* next = block_link_next(block);
+    block_set_prev_free(next);
+    block_set_free(block);
+}
+
+static void block_mark_as_used(block_header_t* block)
+{
+    block_header_t* next = block_next(block);
+    block_set_prev_used(next);
+    block_set_used(block);
+}
+
+static size_t align_up(size_t x, size_t align)
+{
+    tlsf_assert(0 == (align & (align - 1)) && "must align to a power of two");
+    return (x + (align - 1)) & ~(align - 1);
+}
+
+static size_t align_down(size_t x, size_t align)
+{
+    tlsf_assert(0 == (align & (align - 1)) && "must align to a power of two");
+    return x - (x & (align - 1));
+}
+
+static void* align_ptr(const void* ptr, size_t align)
+{
+    const tlsfptr_t aligned = (tlsf_cast(tlsfptr_t, ptr) + (align - 1)) & ~(align - 1);
+    tlsf_assert(0 == (align & (align - 1)) && "must align to a power of two");
+    return tlsf_cast(void*, aligned);
+}
+
+/*
+** Adjust an allocation size to be aligned to word size, and no smaller
+** than internal minimum.
+*/
+static size_t adjust_request_size(size_t size, size_t align)
+{
+    size_t adjust = 0;
+    if (size)
+    {
+        const size_t aligned = align_up(size, align);
+
+        /* aligned sized must not exceed block_size_max or we'll go out of bounds on sl_bitmap */
+        if (aligned < block_size_max)
+        {
+            adjust = tlsf_max(aligned, block_size_min);
+        }
+    }
+    return adjust;
+}
+
+/*
+** TLSF utility functions. In most cases, these are direct translations of
+** the documentation found in the white paper.
+*/
+
+static void mapping_insert(size_t size, int* fli, int* sli)
+{
+    int fl, sl;
+    if (size < SMALL_BLOCK_SIZE)
+    {
+        /* Store small blocks in first list. */
+        fl = 0;
+        sl = tlsf_cast(int, size) / (SMALL_BLOCK_SIZE / SL_INDEX_COUNT);
+    }
+    else
+    {
+        fl = tlsf_fls_sizet(size);
+        sl = tlsf_cast(int, size >> (fl - SL_INDEX_COUNT_LOG2)) ^ (1 << SL_INDEX_COUNT_LOG2);
+        fl -= (FL_INDEX_SHIFT - 1);
+    }
+    *fli = fl;
+    *sli = sl;
+}
+
+/* This version rounds up to the next block size (for allocations) */
+static void mapping_search(size_t size, int* fli, int* sli)
+{
+    if (size >= SMALL_BLOCK_SIZE)
+    {
+        const size_t round = (1 << (tlsf_fls_sizet(size) - SL_INDEX_COUNT_LOG2)) - 1;
+        size += round;
+    }
+    mapping_insert(size, fli, sli);
+}
+
+static block_header_t* search_suitable_block(control_t* control, int* fli, int* sli)
+{
+    int fl = *fli;
+    int sl = *sli;
+
+    /*
+    ** First, search for a block in the list associated with the given
+    ** fl/sl index.
+    */
+    unsigned int sl_map = control->sl_bitmap[fl] & (~0U << sl);
+    if (!sl_map)
+    {
+        /* No block exists. Search in the next largest first-level list. */
+        const unsigned int fl_map = control->fl_bitmap & (~0U << (fl + 1));
+        if (!fl_map)
+        {
+            /* No free blocks available, memory has been exhausted. */
+            return 0;
+        }
+
+        fl = tlsf_ffs(fl_map);
+        *fli = fl;
+        sl_map = control->sl_bitmap[fl];
+    }
+    tlsf_assert(sl_map && "internal error - second level bitmap is null");
+    sl = tlsf_ffs(sl_map);
+    *sli = sl;
+
+    /* Return the first block in the free list. */
+    return control->blocks[fl][sl];
+}
+
+/* Remove a free block from the free list.*/
+static void remove_free_block(control_t* control, block_header_t* block, int fl, int sl)
+{
+    block_header_t* prev = block->prev_free;
+    block_header_t* next = block->next_free;
+    tlsf_assert(prev && "prev_free field can not be null");
+    tlsf_assert(next && "next_free field can not be null");
+    next->prev_free = prev;
+    prev->next_free = next;
+
+    /* If this block is the head of the free list, set new head. */
+    if (control->blocks[fl][sl] == block)
+    {
+        control->blocks[fl][sl] = next;
+
+        /* If the new head is null, clear the bitmap. */
+        if (next == &control->block_null)
+        {
+            control->sl_bitmap[fl] &= ~(1U << sl);
+
+            /* If the second bitmap is now empty, clear the fl bitmap. */
+            if (!control->sl_bitmap[fl])
+            {
+                control->fl_bitmap &= ~(1U << fl);
+            }
+        }
+    }
+}
+
+/* Insert a free block into the free block list. */
+static void insert_free_block(control_t* control, block_header_t* block, int fl, int sl)
+{
+    block_header_t* current = control->blocks[fl][sl];
+    tlsf_assert(current && "free list cannot have a null entry");
+    tlsf_assert(block && "cannot insert a null entry into the free list");
+    block->next_free = current;
+    block->prev_free = &control->block_null;
+    current->prev_free = block;
+
+    tlsf_assert(block_to_ptr(block) == align_ptr(block_to_ptr(block), ALIGN_SIZE) && "block not aligned properly");
+    /*
+    ** Insert the new block at the head of the list, and mark the first-
+    ** and second-level bitmaps appropriately.
+    */
+    control->blocks[fl][sl] = block;
+    control->fl_bitmap |= (1U << fl);
+    control->sl_bitmap[fl] |= (1U << sl);
+}
+
+/* Remove a given block from the free list. */
+static void block_remove(control_t* control, block_header_t* block)
+{
+    int fl, sl;
+    mapping_insert(block_size(block), &fl, &sl);
+    remove_free_block(control, block, fl, sl);
+}
+
+/* Insert a given block into the free list. */
+static void block_insert(control_t* control, block_header_t* block)
+{
+    int fl, sl;
+    mapping_insert(block_size(block), &fl, &sl);
+    insert_free_block(control, block, fl, sl);
+}
+
+static int block_can_split(block_header_t* block, size_t size) { return block_size(block) >= sizeof(block_header_t) + size; }
+
+/* Split a block into two, the second of which is free. */
+static block_header_t* block_split(block_header_t* block, size_t size)
+{
+    /* Calculate the amount of space left in the remaining block. */
+    block_header_t* remaining = offset_to_block(block_to_ptr(block), size - block_header_overhead);
+
+    const size_t remain_size = block_size(block) - (size + block_header_overhead);
+
+    tlsf_assert(block_to_ptr(remaining) == align_ptr(block_to_ptr(remaining), ALIGN_SIZE) && "remaining block not aligned properly");
+
+    tlsf_assert(block_size(block) == remain_size + size + block_header_overhead);
+    block_set_size(remaining, remain_size);
+    tlsf_assert(block_size(remaining) >= block_size_min && "block split with invalid size");
+
+    block_set_size(block, size);
+    block_mark_as_free(remaining);
+
+    return remaining;
+}
+
+/* Absorb a free block's storage into an adjacent previous free block. */
+static block_header_t* block_absorb(block_header_t* prev, block_header_t* block)
+{
+    tlsf_assert(!block_is_last(prev) && "previous block can't be last");
+    /* Note: Leaves flags untouched. */
+    prev->size += block_size(block) + block_header_overhead;
+    block_link_next(prev);
+    return prev;
+}
+
+/* Merge a just-freed block with an adjacent previous free block. */
+static block_header_t* block_merge_prev(control_t* control, block_header_t* block)
+{
+    if (block_is_prev_free(block))
+    {
+        block_header_t* prev = block_prev(block);
+        tlsf_assert(prev && "prev physical block can't be null");
+        tlsf_assert(block_is_free(prev) && "prev block is not free though marked as such");
+        block_remove(control, prev);
+        block = block_absorb(prev, block);
+    }
+
+    return block;
+}
+
+/* Merge a just-freed block with an adjacent free block. */
+static block_header_t* block_merge_next(control_t* control, block_header_t* block)
+{
+    block_header_t* next = block_next(block);
+    tlsf_assert(next && "next physical block can't be null");
+
+    if (block_is_free(next))
+    {
+        tlsf_assert(!block_is_last(block) && "previous block can't be last");
+        block_remove(control, next);
+        block = block_absorb(block, next);
+    }
+
+    return block;
+}
+
+/* Trim any trailing block space off the end of a block, return to pool. */
+static void block_trim_free(control_t* control, block_header_t* block, size_t size)
+{
+    tlsf_assert(block_is_free(block) && "block must be free");
+    if (block_can_split(block, size))
+    {
+        block_header_t* remaining_block = block_split(block, size);
+        block_link_next(block);
+        block_set_prev_free(remaining_block);
+        block_insert(control, remaining_block);
+    }
+}
+
+/* Trim any trailing block space off the end of a used block, return to pool. */
+static void block_trim_used(control_t* control, block_header_t* block, size_t size)
+{
+    tlsf_assert(!block_is_free(block) && "block must be used");
+    if (block_can_split(block, size))
+    {
+        /* If the next block is free, we must coalesce. */
+        block_header_t* remaining_block = block_split(block, size);
+        block_set_prev_used(remaining_block);
+
+        remaining_block = block_merge_next(control, remaining_block);
+        block_insert(control, remaining_block);
+    }
+}
+
+static block_header_t* block_trim_free_leading(control_t* control, block_header_t* block, size_t size)
+{
+    block_header_t* remaining_block = block;
+    if (block_can_split(block, size))
+    {
+        /* We want the 2nd block. */
+        remaining_block = block_split(block, size - block_header_overhead);
+        block_set_prev_free(remaining_block);
+
+        block_link_next(block);
+        block_insert(control, block);
+    }
+
+    return remaining_block;
+}
+
+static block_header_t* block_locate_free(control_t* control, size_t size)
+{
+    int fl = 0, sl = 0;
+    block_header_t* block = 0;
+
+    if (size)
+    {
+        mapping_search(size, &fl, &sl);
+
+        /*
+        ** mapping_search can futz with the size, so for excessively large sizes it can sometimes wind up
+        ** with indices that are off the end of the block array.
+        ** So, we protect against that here, since this is the only callsite of mapping_search.
+        ** Note that we don't need to check sl, since it comes from a modulo operation that guarantees it's always in range.
+        */
+        if (fl < FL_INDEX_COUNT)
+        {
+            block = search_suitable_block(control, &fl, &sl);
+        }
+    }
+
+    if (block)
+    {
+        tlsf_assert(block_size(block) >= size);
+        remove_free_block(control, block, fl, sl);
+    }
+
+    return block;
+}
+
+static void* block_prepare_used(control_t* control, block_header_t* block, size_t size)
+{
+    void* p = 0;
+    if (block)
+    {
+        tlsf_assert(size && "size must be non-zero");
+        block_trim_free(control, block, size);
+        block_mark_as_used(block);
+        p = block_to_ptr(block);
+    }
+    return p;
+}
+
+/* Clear structure and point all empty lists at the null block. */
+static void control_construct(control_t* control)
+{
+    int i, j;
+
+    control->block_null.next_free = &control->block_null;
+    control->block_null.prev_free = &control->block_null;
+
+    control->fl_bitmap = 0;
+    for (i = 0; i < FL_INDEX_COUNT; ++i)
+    {
+        control->sl_bitmap[i] = 0;
+        for (j = 0; j < SL_INDEX_COUNT; ++j)
+        {
+            control->blocks[i][j] = &control->block_null;
+        }
+    }
+}
+
+/*
+** Debugging utilities.
+*/
+
+typedef struct integrity_t
+{
+    int prev_status;
+    int status;
+} integrity_t;
+
+#define tlsf_insist(x)  \
+    {                   \
+        tlsf_assert(x); \
+        if (!(x))       \
+        {               \
+            status--;   \
+        }               \
+    }
+
+static void integrity_walker(void* ptr, size_t size, int used, void* user)
+{
+    block_header_t* block = block_from_ptr(ptr);
+    integrity_t* integ = tlsf_cast(integrity_t*, user);
+    const int this_prev_status = block_is_prev_free(block) ? 1 : 0;
+    const int this_status = block_is_free(block) ? 1 : 0;
+    const size_t this_block_size = block_size(block);
+
+    int status = 0;
+    (void)used;
+    tlsf_insist(integ->prev_status == this_prev_status && "prev status incorrect");
+    tlsf_insist(size == this_block_size && "block size incorrect");
+
+    integ->prev_status = this_status;
+    integ->status += status;
+}
+
+int tlsf_check(tlsf_t tlsf)
+{
+    int i, j;
+
+    control_t* control = tlsf_cast(control_t*, tlsf);
+    int status = 0;
+
+    /* Check that the free lists and bitmaps are accurate. */
+    for (i = 0; i < FL_INDEX_COUNT; ++i)
+    {
+        for (j = 0; j < SL_INDEX_COUNT; ++j)
+        {
+            const int fl_map = control->fl_bitmap & (1U << i);
+            const int sl_list = control->sl_bitmap[i];
+            const int sl_map = sl_list & (1U << j);
+            const block_header_t* block = control->blocks[i][j];
+
+            /* Check that first- and second-level lists agree. */
+            if (!fl_map)
+            {
+                tlsf_insist(!sl_map && "second-level map must be null");
+            }
+
+            if (!sl_map)
+            {
+                tlsf_insist(block == &control->block_null && "block list must be null");
+                continue;
+            }
+
+            /* Check that there is at least one free block. */
+            tlsf_insist(sl_list && "no free blocks in second-level map");
+            tlsf_insist(block != &control->block_null && "block should not be null");
+
+            while (block != &control->block_null)
+            {
+                int fli, sli;
+                tlsf_insist(block_is_free(block) && "block should be free");
+                tlsf_insist(!block_is_prev_free(block) && "blocks should have coalesced");
+                tlsf_insist(!block_is_free(block_next(block)) && "blocks should have coalesced");
+                tlsf_insist(block_is_prev_free(block_next(block)) && "block should be free");
+                tlsf_insist(block_size(block) >= block_size_min && "block not minimum size");
+
+                mapping_insert(block_size(block), &fli, &sli);
+                tlsf_insist(fli == i && sli == j && "block size indexed in wrong list");
+                block = block->next_free;
+            }
+        }
+    }
+
+    return status;
+}
+
+#undef tlsf_insist
+
+static void default_walker(void* ptr, size_t size, int used, void* user)
+{
+    (void)user;
+    printf("\t%p %s size: %x (%p)\n", ptr, used ? "used" : "free", (unsigned int)size, block_from_ptr(ptr));
+}
+
+void tlsf_walk_pool(pool_t pool, tlsf_walker walker, void* user)
+{
+    tlsf_walker pool_walker = walker ? walker : default_walker;
+    block_header_t* block = offset_to_block(pool, -(int)block_header_overhead);
+
+    while (block && !block_is_last(block))
+    {
+        pool_walker(block_to_ptr(block), block_size(block), !block_is_free(block), user);
+        block = block_next(block);
+    }
+}
+
+size_t tlsf_block_size(void* ptr)
+{
+    size_t size = 0;
+    if (ptr)
+    {
+        const block_header_t* block = block_from_ptr(ptr);
+        size = block_size(block);
+    }
+    return size;
+}
+
+int tlsf_check_pool(pool_t pool)
+{
+    /* Check that the blocks are physically correct. */
+    integrity_t integ = {0, 0};
+    tlsf_walk_pool(pool, integrity_walker, &integ);
+
+    return integ.status;
+}
+
+/*
+** Size of the TLSF structures in a given memory block passed to
+** tlsf_create, equal to the size of a control_t
+*/
+size_t tlsf_size(void) { return sizeof(control_t); }
+
+size_t tlsf_align_size(void) { return ALIGN_SIZE; }
+
+size_t tlsf_block_size_min(void) { return block_size_min; }
+
+size_t tlsf_block_size_max(void) { return block_size_max; }
+
+/*
+** Overhead of the TLSF structures in a given memory block passed to
+** tlsf_add_pool, equal to the overhead of a free block and the
+** sentinel block.
+*/
+size_t tlsf_pool_overhead(void) { return 2 * block_header_overhead; }
+
+size_t tlsf_alloc_overhead(void) { return block_header_overhead; }
+
+pool_t tlsf_add_pool(tlsf_t tlsf, void* mem, size_t bytes)
+{
+    block_header_t* block;
+    block_header_t* next;
+
+    const size_t pool_overhead = tlsf_pool_overhead();
+    const size_t pool_bytes = align_down(bytes - pool_overhead, ALIGN_SIZE);
+
+    if (((ptrdiff_t)mem % ALIGN_SIZE) != 0)
+    {
+        printf("tlsf_add_pool: Memory must be aligned by %u bytes.\n", (unsigned int)ALIGN_SIZE);
+        return 0;
+    }
+
+    if (pool_bytes < block_size_min || pool_bytes > block_size_max)
+    {
+#if defined(TLSF_64BIT)
+        printf("tlsf_add_pool: Memory size must be between 0x%x and 0x%x00 bytes.\n", (unsigned int)(pool_overhead + block_size_min),
+               (unsigned int)((pool_overhead + block_size_max) / 256));
+#else
+        printf("tlsf_add_pool: Memory size must be between %u and %u bytes.\n", (unsigned int)(pool_overhead + block_size_min),
+               (unsigned int)(pool_overhead + block_size_max));
+#endif
+        return 0;
+    }
+
+    /*
+    ** Create the main free block. Offset the start of the block slightly
+    ** so that the prev_phys_block field falls outside of the pool -
+    ** it will never be used.
+    */
+    block = offset_to_block(mem, -(tlsfptr_t)block_header_overhead);
+    block_set_size(block, pool_bytes);
+    block_set_free(block);
+    block_set_prev_used(block);
+    block_insert(tlsf_cast(control_t*, tlsf), block);
+
+    /* Split the block to create a zero-size sentinel block. */
+    next = block_link_next(block);
+    block_set_size(next, 0);
+    block_set_used(next);
+    block_set_prev_free(next);
+
+    return mem;
+}
+
+void tlsf_remove_pool(tlsf_t tlsf, pool_t pool)
+{
+    control_t* control = tlsf_cast(control_t*, tlsf);
+    block_header_t* block = offset_to_block(pool, -(int)block_header_overhead);
+
+    int fl = 0, sl = 0;
+
+    tlsf_assert(block_is_free(block) && "block should be free");
+    tlsf_assert(!block_is_free(block_next(block)) && "next block should not be free");
+    tlsf_assert(block_size(block_next(block)) == 0 && "next block size should be zero");
+
+    mapping_insert(block_size(block), &fl, &sl);
+    remove_free_block(control, block, fl, sl);
+}
+
+/*
+** TLSF main interface.
+*/
+
+#if _DEBUG
+int test_ffs_fls()
+{
+    /* Verify ffs/fls work properly. */
+    int rv = 0;
+    rv += (tlsf_ffs(0) == -1) ? 0 : 0x1;
+    rv += (tlsf_fls(0) == -1) ? 0 : 0x2;
+    rv += (tlsf_ffs(1) == 0) ? 0 : 0x4;
+    rv += (tlsf_fls(1) == 0) ? 0 : 0x8;
+    rv += (tlsf_ffs(0x80000000) == 31) ? 0 : 0x10;
+    rv += (tlsf_ffs(0x80008000) == 15) ? 0 : 0x20;
+    rv += (tlsf_fls(0x80000008) == 31) ? 0 : 0x40;
+    rv += (tlsf_fls(0x7FFFFFFF) == 30) ? 0 : 0x80;
+
+#if defined(TLSF_64BIT)
+    rv += (tlsf_fls_sizet(0x80000000) == 31) ? 0 : 0x100;
+    rv += (tlsf_fls_sizet(0x100000000) == 32) ? 0 : 0x200;
+    rv += (tlsf_fls_sizet(0xffffffffffffffff) == 63) ? 0 : 0x400;
+#endif
+
+    if (rv)
+    {
+        printf("test_ffs_fls: %x ffs/fls tests failed.\n", rv);
+    }
+    return rv;
+}
+#endif
+
+tlsf_t tlsf_create(void* mem)
+{
+#if _DEBUG
+    if (test_ffs_fls())
+    {
+        return 0;
+    }
+#endif
+
+    if (((tlsfptr_t)mem % ALIGN_SIZE) != 0)
+    {
+        printf("tlsf_create: Memory must be aligned to %u bytes.\n", (unsigned int)ALIGN_SIZE);
+        return 0;
+    }
+
+    control_construct(tlsf_cast(control_t*, mem));
+
+    return tlsf_cast(tlsf_t, mem);
+}
+
+tlsf_t tlsf_create_with_pool(void* mem, size_t bytes)
+{
+    tlsf_t tlsf = tlsf_create(mem);
+    tlsf_add_pool(tlsf, (char*)mem + tlsf_size(), bytes - tlsf_size());
+    return tlsf;
+}
+
+void tlsf_destroy(tlsf_t tlsf)
+{
+    /* Nothing to do. */
+    (void)tlsf;
+}
+
+pool_t tlsf_get_pool(tlsf_t tlsf) { return tlsf_cast(pool_t, (char*)tlsf + tlsf_size()); }
+
+void* tlsf_malloc(tlsf_t tlsf, size_t size)
+{
+    control_t* control = tlsf_cast(control_t*, tlsf);
+    const size_t adjust = adjust_request_size(size, ALIGN_SIZE);
+    block_header_t* block = block_locate_free(control, adjust);
+    return block_prepare_used(control, block, adjust);
+}
+
+void* tlsf_memalign(tlsf_t tlsf, size_t align, size_t size)
+{
+    control_t* control = tlsf_cast(control_t*, tlsf);
+    const size_t adjust = adjust_request_size(size, ALIGN_SIZE);
+
+    /*
+    ** We must allocate an additional minimum block size bytes so that if
+    ** our free block will leave an alignment gap which is smaller, we can
+    ** trim a leading free block and release it back to the pool. We must
+    ** do this because the previous physical block is in use, therefore
+    ** the prev_phys_block field is not valid, and we can't simply adjust
+    ** the size of that block.
+    */
+    const size_t gap_minimum = sizeof(block_header_t);
+    const size_t size_with_gap = adjust_request_size(adjust + align + gap_minimum, align);
+
+    /*
+    ** If alignment is less than or equals base alignment, we're done.
+    ** If we requested 0 bytes, return null, as tlsf_malloc(0) does.
+    */
+    const size_t aligned_size = (adjust && align > ALIGN_SIZE) ? size_with_gap : adjust;
+
+    block_header_t* block = block_locate_free(control, aligned_size);
+
+    /* This can't be a static assert. */
+    tlsf_assert(sizeof(block_header_t) == block_size_min + block_header_overhead);
+
+    if (block)
+    {
+        void* ptr = block_to_ptr(block);
+        void* aligned = align_ptr(ptr, align);
+        size_t gap = tlsf_cast(size_t, tlsf_cast(tlsfptr_t, aligned) - tlsf_cast(tlsfptr_t, ptr));
+
+        /* If gap size is too small, offset to next aligned boundary. */
+        if (gap && gap < gap_minimum)
+        {
+            const size_t gap_remain = gap_minimum - gap;
+            const size_t offset = tlsf_max(gap_remain, align);
+            const void* next_aligned = tlsf_cast(void*, tlsf_cast(tlsfptr_t, aligned) + offset);
+
+            aligned = align_ptr(next_aligned, align);
+            gap = tlsf_cast(size_t, tlsf_cast(tlsfptr_t, aligned) - tlsf_cast(tlsfptr_t, ptr));
+        }
+
+        if (gap)
+        {
+            tlsf_assert(gap >= gap_minimum && "gap size too small");
+            block = block_trim_free_leading(control, block, gap);
+        }
+    }
+
+    return block_prepare_used(control, block, adjust);
+}
+
+void tlsf_free(tlsf_t tlsf, void* ptr)
+{
+    /* Don't attempt to free a NULL pointer. */
+    if (ptr)
+    {
+        control_t* control = tlsf_cast(control_t*, tlsf);
+        block_header_t* block = block_from_ptr(ptr);
+        tlsf_assert(!block_is_free(block) && "block already marked as free");
+        block_mark_as_free(block);
+        block = block_merge_prev(control, block);
+        block = block_merge_next(control, block);
+        block_insert(control, block);
+    }
+}
+
+/*
+** The TLSF block information provides us with enough information to
+** provide a reasonably intelligent implementation of realloc, growing or
+** shrinking the currently allocated block as required.
+**
+** This routine handles the somewhat esoteric edge cases of realloc:
+** - a non-zero size with a null pointer will behave like malloc
+** - a zero size with a non-null pointer will behave like free
+** - a request that cannot be satisfied will leave the original buffer
+**   untouched
+** - an extended buffer size will leave the newly-allocated area with
+**   contents undefined
+*/
+void* tlsf_realloc(tlsf_t tlsf, void* ptr, size_t size)
+{
+    control_t* control = tlsf_cast(control_t*, tlsf);
+    void* p = 0;
+
+    /* Zero-size requests are treated as free. */
+    if (ptr && size == 0)
+    {
+        tlsf_free(tlsf, ptr);
+    }
+    /* Requests with NULL pointers are treated as malloc. */
+    else if (!ptr)
+    {
+        p = tlsf_malloc(tlsf, size);
+    }
+    else
+    {
+        block_header_t* block = block_from_ptr(ptr);
+        block_header_t* next = block_next(block);
+
+        const size_t cursize = block_size(block);
+        const size_t combined = cursize + block_size(next) + block_header_overhead;
+        const size_t adjust = adjust_request_size(size, ALIGN_SIZE);
+
+        tlsf_assert(!block_is_free(block) && "block already marked as free");
+
+        /*
+        ** If the next block is used, or when combined with the current
+        ** block, does not offer enough space, we must reallocate and copy.
+        */
+        if (adjust > cursize && (!block_is_free(next) || adjust > combined))
+        {
+            p = tlsf_malloc(tlsf, size);
+            if (p)
+            {
+                const size_t minsize = tlsf_min(cursize, size);
+                memcpy(p, ptr, minsize);
+                tlsf_free(tlsf, ptr);
+            }
+        }
+        else
+        {
+            /* Do we need to expand to the next block? */
+            if (adjust > cursize)
+            {
+                block_merge_next(control, block);
+                block_mark_as_used(block);
+            }
+
+            /* Trim the resulting block and return the original pointer. */
+            block_trim_used(control, block, adjust);
+            p = ptr;
+        }
+    }
+
+    return p;
+}

--- a/src/clean-core/detail/lib/tlsf.hh
+++ b/src/clean-core/detail/lib/tlsf.hh
@@ -1,0 +1,92 @@
+#pragma once
+#ifndef INCLUDED_tlsf
+#define INCLUDED_tlsf
+
+/*
+** Two Level Segregated Fit memory allocator, version 3.1.
+** Written by Matthew Conte
+**	http://tlsf.baisoku.org
+**
+** Based on the original documentation by Miguel Masmano:
+**	http://www.gii.upv.es/tlsf/main/docs
+**
+** This implementation was written to the specification
+** of the document, therefore no GPL restrictions apply.
+**
+** Copyright (c) 2006-2016, Matthew Conte
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are met:
+**     * Redistributions of source code must retain the above copyright
+**       notice, this list of conditions and the following disclaimer.
+**     * Redistributions in binary form must reproduce the above copyright
+**       notice, this list of conditions and the following disclaimer in the
+**       documentation and/or other materials provided with the distribution.
+**     * Neither the name of the copyright holder nor the
+**       names of its contributors may be used to endorse or promote products
+**       derived from this software without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+** ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+** WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL MATTHEW CONTE BE LIABLE FOR ANY
+** DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+** (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+** LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+** ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+** SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stddef.h>
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+    /* tlsf_t: a TLSF structure. Can contain 1 to N pools. */
+    /* pool_t: a block of memory that TLSF can manage. */
+    typedef void* tlsf_t;
+    typedef void* pool_t;
+
+    /* Create/destroy a memory pool. */
+    tlsf_t tlsf_create(void* mem);
+    tlsf_t tlsf_create_with_pool(void* mem, size_t bytes);
+    void tlsf_destroy(tlsf_t tlsf);
+    pool_t tlsf_get_pool(tlsf_t tlsf);
+
+    /* Add/remove memory pools. */
+    pool_t tlsf_add_pool(tlsf_t tlsf, void* mem, size_t bytes);
+    void tlsf_remove_pool(tlsf_t tlsf, pool_t pool);
+
+    /* malloc/memalign/realloc/free replacements. */
+    void* tlsf_malloc(tlsf_t tlsf, size_t bytes);
+    void* tlsf_memalign(tlsf_t tlsf, size_t align, size_t bytes);
+    void* tlsf_realloc(tlsf_t tlsf, void* ptr, size_t size);
+    void tlsf_free(tlsf_t tlsf, void* ptr);
+
+    /* Returns internal block size, not original request size */
+    size_t tlsf_block_size(void* ptr);
+
+    /* Overheads/limits of internal structures. */
+    size_t tlsf_size(void);
+    size_t tlsf_align_size(void);
+    size_t tlsf_block_size_min(void);
+    size_t tlsf_block_size_max(void);
+    size_t tlsf_pool_overhead(void);
+    size_t tlsf_alloc_overhead(void);
+
+    /* Debugging. */
+    typedef void (*tlsf_walker)(void* ptr, size_t size, int used, void* user);
+    void tlsf_walk_pool(pool_t pool, tlsf_walker walker, void* user);
+    /* Returns nonzero if any internal consistency check fails. */
+    int tlsf_check(tlsf_t tlsf);
+    int tlsf_check_pool(pool_t pool);
+
+#if defined(__cplusplus)
+};
+#endif
+
+#endif

--- a/src/clean-core/fwd.hh
+++ b/src/clean-core/fwd.hh
@@ -95,5 +95,14 @@ struct poly_unique_ptr;
 
 // allocators
 struct allocator;
+struct linear_allocator;
+struct system_allocator_t;
+struct stack_allocator;
+struct scratch_allocator;
+struct tlsf_allocator;
+struct atomic_pool_allocator;
+struct atomic_linear_allocator;
+struct synced_tlsf_allocator;
+
 extern allocator* const system_allocator;
 }

--- a/src/clean-core/macros.hh
+++ b/src/clean-core/macros.hh
@@ -19,6 +19,31 @@
 #define CC_COMPILER_POSIX
 #endif
 
+// =========
+// compilation modes
+
+#ifdef CC_COMPILER_MSVC
+#ifdef _CPPRTTI
+#define CC_HAS_RTTI
+#endif
+#ifdef _CPPUNWIND
+#define CC_HAS_CPP_EXCEPTIONS
+#endif
+#elif defined(CC_COMPILER_CLANG)
+#if __has_feature(cxx_rtti)
+#define CC_HAS_RTTI
+#endif
+#if __EXCEPTIONS && __has_feature(cxx_exceptions)
+#define CC_HAS_CPP_EXCEPTIONS
+#endif
+#elif defined(CC_COMPILER_GCC)
+#ifdef __GXX_RTTI
+#define CC_HAS_RTTI
+#endif
+#if __EXCEPTIONS
+#define CC_HAS_CPP_EXCEPTIONS
+#endif
+#endif
 
 // =========
 // operating system

--- a/src/clean-core/threadsafe_allocators.cc
+++ b/src/clean-core/threadsafe_allocators.cc
@@ -1,8 +1,14 @@
 #include "threadsafe_allocators.hh"
 
-cc::atomic_pool_allocator::atomic_pool_allocator(span<cc::byte> buffer, cc::size_t block_size)
-  : _buffer_begin(buffer.data()), _buffer_size(buffer.size()), _block_size(block_size)
+cc::atomic_pool_allocator::atomic_pool_allocator(span<cc::byte> buffer, cc::size_t block_size) { initialize(buffer, block_size); }
+
+void cc::atomic_pool_allocator::initialize(span<cc::byte> buffer, cc::size_t block_size)
 {
+    CC_ASSERT(_buffer_begin == nullptr && "double initialize");
+    _buffer_begin = buffer.data();
+    _buffer_size = buffer.size();
+    _block_size = block_size;
+
     CC_ASSERT(_block_size >= sizeof(byte*) && "blocks must be large enough to accomodate a pointer");
     CC_ASSERT(_block_size <= _buffer_size && "not enough memory to allocate a single block");
 

--- a/src/clean-core/threadsafe_allocators.cc
+++ b/src/clean-core/threadsafe_allocators.cc
@@ -1,0 +1,25 @@
+#include "threadsafe_allocators.hh"
+
+cc::atomic_pool_allocator::atomic_pool_allocator(span<cc::byte> buffer, cc::size_t block_size)
+  : _buffer_begin(buffer.data()), _buffer_size(buffer.size()), _block_size(block_size)
+{
+    CC_ASSERT(_block_size >= sizeof(byte*) && "blocks must be large enough to accomodate a pointer");
+    CC_ASSERT(_block_size <= _buffer_size && "not enough memory to allocate a single block");
+
+    size_t const num_blocks = _buffer_size / _block_size;
+
+    // initialize linked list
+    for (auto i = 0u; i < num_blocks - 1; ++i)
+    {
+        byte* node_ptr = &_buffer_begin[i * block_size];
+        new (cc::placement_new, node_ptr) byte*(&_buffer_begin[(i + 1) * block_size]);
+    }
+
+    // initialize linked list tail
+    {
+        byte* tail_ptr = &_buffer_begin[(num_blocks - 1) * block_size];
+        new (cc::placement_new, tail_ptr) byte*(nullptr);
+    }
+
+    _first_free_node = &_buffer_begin[0];
+}

--- a/src/clean-core/threadsafe_allocators.hh
+++ b/src/clean-core/threadsafe_allocators.hh
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <atomic>
+#include <mutex>
+
+#include <clean-core/allocator.hh>
+#include <clean-core/new.hh>
+#include <clean-core/utility.hh>
+
+namespace cc
+{
+/// thread safe pool allocator, O(1) alloc and free
+/// cannot alloc buffers > block_size (ie. does not search contiguous blocks)
+/// provided buffer and block size must be aligned to a multiple of all requests (this is verified)
+struct atomic_pool_allocator final : allocator
+{
+    byte* alloc(size_t size, size_t align = alignof(std::max_align_t)) override
+    {
+        if (size > _block_size)
+            return nullptr;
+
+        CC_ASSERT(!is_full() && "pool_allocator full");
+
+        // CAS-loop to acquire a free node and write the matching next pointer
+        bool cas_success = false;
+        byte* acquired_node = nullptr;
+        do
+        {
+            // acquire-candidate: the current value of _first_free_node
+            acquired_node = _first_free_node.load(std::memory_order_acquire);
+            // read the in-place next pointer of this node
+            byte* const next_pointer_of_acquired = *reinterpret_cast<byte**>(acquired_node);
+
+            // compare-exchange these two - spurious failure if raced
+            cas_success = std::atomic_compare_exchange_weak_explicit(&_first_free_node, &acquired_node, next_pointer_of_acquired,
+                                                                     std::memory_order_seq_cst, std::memory_order_relaxed);
+        } while (!cas_success);
+
+        CC_ASSERT(cc::is_aligned(acquired_node, align) && "pool buffer and blocks must be aligned to a multiple of all requests");
+        return acquired_node;
+    }
+
+    void free(void* ptr) override
+    {
+        if (!ptr)
+            return;
+
+        byte* const freed_node = static_cast<byte*>(ptr);
+        CC_ASSERT(freed_node >= _buffer_begin && freed_node - _buffer_begin <= ptrdiff_t(_buffer_size) && "pointer in pool_allocator::free is not part of the buffer");
+        CC_ASSERT((freed_node - _buffer_begin) % _block_size == 0 && "freed pointer is not on a node boundary");
+
+        // write the in-place next pointer of this node
+        bool cas_success = false;
+        do
+        {
+            byte* expected_first_free = _first_free_node.load(std::memory_order_acquire);
+
+            // write the in-place next pointer of this node provisionally
+            new (cc::placement_new, freed_node) byte*(expected_first_free);
+
+            // CAS write the newly released node if the expected wasn't raced
+            cas_success = std::atomic_compare_exchange_weak_explicit(&_first_free_node, &expected_first_free, freed_node, std::memory_order_seq_cst,
+                                                                     std::memory_order_relaxed);
+        } while (!cas_success);
+    }
+
+    bool is_full() const { return _first_free_node == nullptr; }
+    size_t max_size_bytes() const { return _buffer_size; }
+    size_t block_size_bytes() const { return _block_size; }
+    size_t max_num_blocks() const { return _buffer_size / _block_size; }
+
+    atomic_pool_allocator() = default;
+    atomic_pool_allocator(span<byte> buffer, size_t block_size);
+
+private:
+    byte* _buffer_begin = nullptr;
+    std::atomic<byte*> _first_free_node = nullptr;
+    size_t _buffer_size = 0;
+    size_t _block_size = 0;
+};
+
+/// thread safe version of cc::linear_allocator
+struct atomic_linear_allocator final : allocator
+{
+    byte* alloc(size_t size, size_t align = alignof(std::max_align_t)) override
+    {
+        CC_ASSERT(_buffer_begin != nullptr && "atomic_linear_allocator unintialized");
+
+        auto const buffer_size = size + align - 1; // align worst case buffer to satisfy up-aligning
+        auto const buffer_start = _offset.fetch_add(buffer_size, std::memory_order_acquire);
+
+        auto* const alloc_start = _buffer_begin + buffer_start;
+        auto* const padded_res = cc::align_up(alloc_start, align);
+
+        CC_ASSERT(padded_res - alloc_start < std::ptrdiff_t(align) && "up-align OOB");
+        CC_ASSERT(padded_res + size <= _buffer_end && "atomic_linear_allocator overcommitted");
+
+        return padded_res;
+    }
+
+    void free(void* ptr) override
+    {
+        // no-op
+        (void)ptr;
+    }
+
+    void reset() { _offset.store(0, std::memory_order_release); }
+
+    size_t allocated_size() const { return _offset; }
+    size_t max_size() const { return _buffer_end - _buffer_begin; }
+    float allocated_ratio() const { return allocated_size() / float(max_size()); }
+
+    atomic_linear_allocator() = default;
+    atomic_linear_allocator(span<byte> buffer) : _buffer_begin(buffer.data()), _offset(0), _buffer_end(buffer.data() + buffer.size()) {}
+
+private:
+    byte* _buffer_begin = nullptr;
+    std::atomic<std::size_t> _offset = {0};
+    byte* _buffer_end = nullptr;
+};
+
+
+/// Synchronized (mutexed) version of tlsf_allocator
+struct synced_tlsf_allocator final : allocator
+{
+    synced_tlsf_allocator() = default;
+    synced_tlsf_allocator(cc::span<std::byte> buffer) : _backing(buffer) {}
+    ~synced_tlsf_allocator() { _backing.destroy(); }
+
+
+    std::byte* alloc(size_t size, size_t align = alignof(std::max_align_t)) override
+    {
+        auto lg = std::lock_guard(_mutex);
+        return _backing.alloc(size, align);
+    }
+
+    void free(void* ptr) override
+    {
+        auto lg = std::lock_guard(_mutex);
+        _backing.free(ptr);
+    }
+
+    std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t)) override
+    {
+        auto lg = std::lock_guard(_mutex);
+        return _backing.realloc(ptr, old_size, new_size, align);
+    }
+
+    void initialize(cc::span<std::byte> buffer) { _backing.initialize(buffer); }
+    void destroy() { _backing.destroy(); }
+
+private:
+    std::mutex _mutex;
+    cc::tlsf_allocator _backing;
+};
+}

--- a/src/clean-core/threadsafe_allocators.hh
+++ b/src/clean-core/threadsafe_allocators.hh
@@ -74,6 +74,12 @@ struct atomic_pool_allocator final : allocator
         return size_t(node - _buffer_begin);
     }
 
+    size_t get_node_index(void const* ptr) const
+    {
+        auto const offset_bytes = get_node_offset_bytes(ptr);
+        return offset_bytes / _block_size;
+    }
+
     bool is_full() const { return _first_free_node == nullptr; }
     size_t max_size_bytes() const { return _buffer_size; }
     size_t block_size_bytes() const { return _block_size; }

--- a/src/clean-core/threadsafe_allocators.hh
+++ b/src/clean-core/threadsafe_allocators.hh
@@ -64,6 +64,16 @@ struct atomic_pool_allocator final : allocator
         } while (!cas_success);
     }
 
+    /// returns the offset of a node to the buffer start in bytes
+    size_t get_node_offset_bytes(void const* ptr) const
+    {
+        byte const* const node = static_cast<byte const*>(ptr);
+        CC_ASSERT(node >= _buffer_begin && node - _buffer_begin <= ptrdiff_t(_buffer_size)
+                  && "pointer in pool_allocator::get_node_offset_bytes is not part of the buffer");
+        CC_ASSERT((node - _buffer_begin) % _block_size == 0 && "pointer is not on a node boundary");
+        return size_t(node - _buffer_begin);
+    }
+
     bool is_full() const { return _first_free_node == nullptr; }
     size_t max_size_bytes() const { return _buffer_size; }
     size_t block_size_bytes() const { return _block_size; }
@@ -71,6 +81,8 @@ struct atomic_pool_allocator final : allocator
 
     atomic_pool_allocator() = default;
     atomic_pool_allocator(span<byte> buffer, size_t block_size);
+
+    void initialize(span<byte> buffer, size_t block_size);
 
 private:
     byte* _buffer_begin = nullptr;

--- a/src/clean-core/threadsafe_allocators.hh
+++ b/src/clean-core/threadsafe_allocators.hh
@@ -84,6 +84,12 @@ struct atomic_pool_allocator final : allocator
 
     void initialize(span<byte> buffer, size_t block_size);
 
+    template <class T>
+    void initialize_from_array(span<T> elements, size_t block_size_in_elements = 1)
+    {
+        return initialize(cc::as_byte_span(elements), sizeof(T) * block_size_in_elements);
+    }
+
 private:
     byte* _buffer_begin = nullptr;
     std::atomic<byte*> _first_free_node = nullptr;

--- a/src/clean-core/utility.hh
+++ b/src/clean-core/utility.hh
@@ -93,4 +93,11 @@ template <class T>
 {
     return align_up_masked(value, alignment - 1);
 }
+
+/// returns true if the value (pointer or integer) is aligned at the given boundary
+template <class T>
+[[nodiscard]] constexpr bool is_aligned(T value, size_t alignment)
+{
+    return 0 == ((size_t)value & (alignment - 1));
+}
 }


### PR DESCRIPTION
### Allocators
- `cc::tlsf_allocator` - Two-Level Segregated Fit ([mattconte/tslf](https://github.com/mattconte/tlsf))
- `threadsafe_allocators.hh`
    - `cc::atomic_linear_allocator`
    - `cc::atomic_pool_allocator`
    - `cc::synced_tlsf_allocator` - mutexed version
- split `allocators.cc` into three TUs
- default move ctors of interface type

### Changes
- `atomic_linked_pool`
    - always destroy all contained elements on destruction
    - now compatible with forward-declared `T`
- `utility.hh`: add `is_aligned`
- Assertions: print stack trace after a failed assertion on Win32 (using [StackWalker](https://github.com/JochenKalmbach/StackWalker))
- `macros.hh`: Add macros about compilation mode: `CC_HAS_RTTI` and `CC_HAS_CPP_EXCEPTIONS`

### CMake
- Add (cmake) option to build a library add via `arcana_add_library` as a DLL
    - Adds the library as SHARED
    - Defines `<LIB>_BUILD_DLL` publicly and `<LIB>_DLL` privately for dllimport/dllexport differentiation
    - (Not used for cc itself)