### PR TITLE
Debug break on-site in CC_ASSERT, vector remove unordered

### DIFF
--- a/src/clean-core/allocator.cc
+++ b/src/clean-core/allocator.cc
@@ -42,7 +42,6 @@ std::byte* align_up_with_header(std::byte* head, size_t align, size_t header_siz
 }
 
 
-
 cc::byte* cc::stack_allocator::alloc(cc::size_t size, cc::size_t align)
 {
     CC_ASSERT(_buffer_begin != nullptr && "stack_allocator uninitialized");

--- a/src/clean-core/assert.cc
+++ b/src/clean-core/assert.cc
@@ -86,4 +86,6 @@ void cc::detail::assertion_failed(assertion_info const& info)
     }
 }
 
+void cc::detail::perform_abort() { std::abort(); }
+
 void cc::set_assertion_handler(void (*handler)(detail::assertion_info const&)) { s_current_handler = handler; }

--- a/src/clean-core/assert.cc
+++ b/src/clean-core/assert.cc
@@ -1,6 +1,5 @@
 #include <clean-core/assert.hh>
 
-#include <clean-core/breakpoint.hh>
 #include <clean-core/macros.hh>
 
 #ifdef CC_OS_WINDOWS
@@ -51,10 +50,6 @@ protected:
 
 #endif
 
-struct assertion_not_handled
-{
-};
-
 using assertion_handler_t = void (*)(cc::detail::assertion_info const&);
 
 thread_local assertion_handler_t s_current_handler = nullptr;
@@ -76,24 +71,19 @@ void default_assertion_handler(cc::detail::assertion_info const& info)
 
     CC_PRINT_STACK_TRACE();
     fflush(stderr);
-
-#if !defined(CC_RELEASE) && !defined(CC_OS_WINDOWS)
-    // on win32, this suppresses the CRT abort/retry debugger attach message
-    cc::breakpoint();
-#endif
-
-    std::abort();
 }
 } // namespace
 
 void cc::detail::assertion_failed(assertion_info const& info)
 {
     if (s_current_handler)
+    {
         s_current_handler(info);
+    }
     else
+    {
         default_assertion_handler(info);
-
-    throw assertion_not_handled{};
+    }
 }
 
 void cc::set_assertion_handler(void (*handler)(detail::assertion_info const&)) { s_current_handler = handler; }

--- a/src/clean-core/assert.hh
+++ b/src/clean-core/assert.hh
@@ -22,8 +22,10 @@
 
 #ifdef CC_COMPILER_MSVC
 #define CC_BREAK_AND_ABORT() (__debugbreak(), std::abort())
-#elif
+#elif defined(CC_COMPILER_POSIX)
 #define CC_BREAK_AND_ABORT() (__builtin_trap(), std::abort())
+#else
+#define CC_BREAK_AND_ABORT() std::abort()
 #endif
 
 // least overhead assertion macros

--- a/src/clean-core/assert.hh
+++ b/src/clean-core/assert.hh
@@ -1,6 +1,30 @@
 #pragma once
 
+#include <cstdlib> // std::abort
+
 #include <clean-core/macros.hh>
+
+#ifdef CC_COMPILER_MSVC
+#include <intrin.h> // __debugbreak
+#endif
+
+// CC_ASSERT(cond) aborts if `cond` is false
+// CC_BOUND_CHECK(var, lb, ub) asserts `lb <= var && var < ub`
+// NOTE: neither macro must contain side effects!
+
+// compile flags
+// CC_ENABLE_ASSERTIONS enables assertions
+// CC_ENABLE_BOUND_CHECKING enables bound checking
+
+
+// the debugger should break on-site, so this cannot hide in a function call
+// comma expression: abort must still be called (if no debugger is attached), and do/while(0) doesn't work in the ternary
+
+#ifdef CC_COMPILER_MSVC
+#define CC_BREAK_AND_ABORT() (__debugbreak(), std::abort())
+#elif
+#define CC_BREAK_AND_ABORT() (__builtin_trap(), std::abort())
+#endif
 
 // least overhead assertion macros
 // see https://godbolt.org/z/BvF_yn
@@ -8,16 +32,8 @@
 // decltype(...) is an unevaluated context, thus eliminating any potential side effect
 // assertion handler is customizable
 
-// ASSERT(cond) aborts if `cond` is false
-// BOUND_CHECK(var, lb, ub) asserts `lb <= var && var < ub`
-// NOTE: neither macro must contain side effects!
-
-// compile flags
-// CC_ENABLE_ASSERTIONS enables assertions
-// CC_ENABLE_BOUND_CHECKING enables bound checking
-
 #define CC_DETAIL_EXECUTE_ASSERT(condition, msg) \
-    (CC_UNLIKELY(!(condition)) ? ::cc::detail::assertion_failed({#condition, CC_PRETTY_FUNC, __FILE__, msg, __LINE__}) : void(0)) // force ;
+    (CC_UNLIKELY(!(condition)) ? (::cc::detail::assertion_failed({#condition, CC_PRETTY_FUNC, __FILE__, msg, __LINE__}), CC_BREAK_AND_ABORT()) : void(0)) // force ;
 
 #define CC_RUNTIME_ASSERT(condition) CC_DETAIL_EXECUTE_ASSERT(condition, nullptr)
 #define CC_RUNTIME_ASSERT_MSG(condition, msg) CC_DETAIL_EXECUTE_ASSERT(condition, msg)

--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -289,10 +289,21 @@ public:
         for (size_t i = 0; i < _size; ++i)
             if (cc::invoke(pred, _data[i]))
             {
-                for (size_t j = i + 1; j < _size; ++j)
-                    _data[j - 1] = cc::move(_data[j]);
-                --_size;
-                _data[_size].~T();
+                this->remove_at(i);
+                return true;
+            }
+        return false;
+    }
+
+    /// removes the first entry where cc::invoke(pred, entry) is true without preserving order
+    /// returns true iff any element was removed
+    template <class Predicate>
+    bool remove_first_unsorted(Predicate&& pred)
+    {
+        for (size_t i = 0; i < _size; ++i)
+            if (cc::invoke(pred, _data[i]))
+            {
+                this->remove_at_unsorted(i);
                 return true;
             }
         return false;
@@ -330,6 +341,14 @@ public:
             _data[i - 1] = cc::move(_data[i]);
         --_size;
         _data[_size].~T();
+    }
+
+    /// removes the element at the given index without preserving order
+    void remove_at_unsorted(size_t idx)
+    {
+        CC_CONTRACT(idx < _size);
+        cc::swap(_data[idx], this->back());
+        this->pop_back();
     }
 
     /// returns true iff any entry is == value

--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -298,12 +298,12 @@ public:
     /// removes the first entry where cc::invoke(pred, entry) is true without preserving order
     /// returns true iff any element was removed
     template <class Predicate>
-    bool remove_first_unsorted(Predicate&& pred)
+    bool remove_first_unordered(Predicate&& pred)
     {
         for (size_t i = 0; i < _size; ++i)
             if (cc::invoke(pred, _data[i]))
             {
-                this->remove_at_unsorted(i);
+                this->remove_at_unordered(i);
                 return true;
             }
         return false;
@@ -344,7 +344,7 @@ public:
     }
 
     /// removes the element at the given index without preserving order
-    void remove_at_unsorted(size_t idx)
+    void remove_at_unordered(size_t idx)
     {
         CC_CONTRACT(idx < _size);
         cc::swap(_data[idx], this->back());


### PR DESCRIPTION
 `CC_ASSERT` used to pollute the callstack and break two functions deep, instead of immediately on location. This changes the breakpoint to be executed directly from the macro after the assert handler returns. In turn, the assert handler itself must return and no longer throws an exception (could be reintroduced afterwards if necessary).

Also added `vector::remove_first_unordered` and `remove_at_unordered` which swap/pops instead of shifting all entries.