### PR TITLE
vector stable_emplace_back

### DIFF
--- a/src/clean-core/alloc_array.hh
+++ b/src/clean-core/alloc_array.hh
@@ -25,8 +25,11 @@ struct alloc_array
         _size = size;
         _data = _alloc(size);
 
-        for (size_t i = 0; i < size; ++i)
-            new (placement_new, &this->_data[i]) T();
+        if constexpr (!std::is_trivially_constructible_v<T>)
+        {
+            for (size_t i = 0; i < size; ++i)
+                new (placement_new, &this->_data[i]) T();
+        }
     }
 
     [[nodiscard]] static alloc_array defaulted(size_t size, cc::allocator* allocator = cc::system_allocator) { return alloc_array(size, allocator); }

--- a/src/clean-core/bits.hh
+++ b/src/clean-core/bits.hh
@@ -145,6 +145,14 @@ constexpr bool is_pow2(uint64 v) { return ((v & (v - uint64(1))) == 0); }
 constexpr uint32 mod_pow2(uint32 v, uint32 divisor) { return v & (divisor - 1); }
 constexpr uint64 mod_pow2(uint64 v, uint64 divisor) { return v & (divisor - 1); }
 
+// computes floor(v / divisor), divisor must be a power of 2
+inline uint32 div_pow2_floor(uint32 v, uint32 divisor) { return v >> bit_log2(divisor); }
+inline uint64 div_pow2_floor(uint64 v, uint64 divisor) { return v >> bit_log2(divisor); }
+
+// computes ceil(v / divisor), v > 0, divisor must be a power of 2
+inline uint32 div_pow2_ceil(uint32 v, uint32 divisor) { return ((v - uint32(1)) >> bit_log2(divisor)) + uint32(1); }
+inline uint64 div_pow2_ceil(uint64 v, uint64 divisor) { return ((v - uint64(1)) >> bit_log2(divisor)) + uint64(1); }
+
 constexpr void set_bit(uint8& val, uint32 bit_idx) { val |= (uint8(1) << bit_idx); }
 constexpr void set_bit(uint16& val, uint32 bit_idx) { val |= (uint16(1) << bit_idx); }
 constexpr void set_bit(uint32& val, uint32 bit_idx) { val |= (uint32(1) << bit_idx); }

--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -154,6 +154,14 @@ public:
     /// adds an element at the end
     T& push_back(T&& value) { return emplace_back(cc::move(value)); }
 
+    /// creates a new element at the end without growing
+    template <class... Args>
+    T& stable_emplace_back(Args&&... args)
+    {
+        CC_ASSERT(_size < _capacity && "At capacity");
+        return *(new (placement_new, &_data[_size++]) T(cc::forward<Args>(args)...));
+    }
+
     /// adds all elements of the range
     template <class Range>
     void push_back_range(Range&& range)

--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -156,7 +156,7 @@ public:
 
     /// creates a new element at the end without growing
     template <class... Args>
-    T& stable_emplace_back(Args&&... args)
+    T& emplace_back_stable(Args&&... args)
     {
         CC_ASSERT(_size < _capacity && "At capacity");
         return *(new (placement_new, &_data[_size++]) T(cc::forward<Args>(args)...));


### PR DESCRIPTION
- Add `stable_emplace_back` to vector_base which never grows and asserts if full
    - Useful for strict memory control or for cases where pointers must remain stable
- Skip unnecessary ctor calls in `alloc_array` (discovered via profiling)