### PR TITLE
Improved assert on Win32, align_down, span copy fix, minor additions

### DIFF
--- a/src/clean-core/allocator.scratch.cc
+++ b/src/clean-core/allocator.scratch.cc
@@ -88,7 +88,7 @@ cc::byte* cc::scratch_allocator::alloc(cc::size_t size, cc::size_t align)
     if (p > _buffer_end)
     {
         // write wraparound marker to the header
-        CC_ASSERT(reinterpret_cast<byte*>(h) < _buffer_end && "programmer error");
+        CC_ASSERT(reinterpret_cast<byte*>(h) + sizeof(scratch_alloc_header) <= _buffer_end && "programmer error");
         uint32_t const num_bytes_until_end = uint32_t(_buffer_end - reinterpret_cast<byte*>(h));
 
         CC_DTRACE_ALLOC_PRINTF("    [alloc]    %zu bytes would wrap, writing %u to wraparound header [%u]\n", size, num_bytes_until_end, get_ptr_offset(h));

--- a/src/clean-core/assert.cc
+++ b/src/clean-core/assert.cc
@@ -9,10 +9,12 @@
 #include <clean-core/native/detail/win32_sanitize_before.inl>
 #include <Windows.h> // required for stackwalker
 #include <crtdbg.h> // _CrtDebugReport
+
+#include <clean-core/detail/lib/StackWalker.hh>
+
 #include <clean-core/native/detail/win32_sanitize_after.inl>
 // clang-format on
 
-#include <clean-core/detail/lib/StackWalker.hh>
 #endif
 
 #include <cstdio>

--- a/src/clean-core/assert.cc
+++ b/src/clean-core/assert.cc
@@ -1,7 +1,5 @@
 #include <clean-core/assert.hh>
 
-#include <csignal>
-
 #include <clean-core/macros.hh>
 
 #ifdef CC_OS_WINDOWS

--- a/src/clean-core/assert.hh
+++ b/src/clean-core/assert.hh
@@ -15,12 +15,14 @@
 // comma expression: abort must still be called (if no debugger is attached), and do/while(0) doesn't work in the ternary
 
 #ifdef CC_COMPILER_MSVC
-#define CC_BREAK_AND_ABORT() (__debugbreak(), ::cc::detail::perform_abort())
+#define CC_BREAK() __debugbreak()
 #elif defined(CC_COMPILER_POSIX)
-#define CC_BREAK_AND_ABORT() (__builtin_trap(), ::cc::detail::perform_abort())
+#define CC_BREAK() __builtin_trap()
 #else
-#define CC_BREAK_AND_ABORT() ::cc::detail::perform_abort()
+#define CC_BREAK() (void)0
 #endif
+
+#define CC_BREAK_AND_ABORT() (CC_BREAK(), ::cc::detail::perform_abort())
 
 // least overhead assertion macros
 // see https://godbolt.org/z/aWW1f8

--- a/src/clean-core/assert.hh
+++ b/src/clean-core/assert.hh
@@ -11,15 +11,16 @@
 // CC_ENABLE_BOUND_CHECKING enables bound checking
 
 
-// the debugger should break on-site, so this cannot hide in a function call
-// comma expression: abort must still be called (if no debugger is attached), and do/while(0) doesn't work in the ternary
+// the debugger should break right in the assert macro, so this cannot hide in a function call
 
 #ifdef CC_COMPILER_MSVC
-#define CC_BREAK() __debugbreak()
+// __debugbreak() terminates immediately without an attached debugger
+#define CC_BREAK() (::cc::detail::is_debugger_connected() ? __debugbreak() : void(0))
 #elif defined(CC_COMPILER_POSIX)
-#define CC_BREAK() __builtin_trap()
+// __builtin_trap() causes an illegal instruction and crashes without an attached debugger
+#define CC_BREAK() (::cc::detail::is_debugger_connected() ? __builtin_trap() : void(0))
 #else
-#define CC_BREAK() (void)0
+#define CC_BREAK() void(0)
 #endif
 
 #define CC_BREAK_AND_ABORT() (CC_BREAK(), ::cc::detail::perform_abort())
@@ -93,8 +94,10 @@ struct assertion_info
 
 CC_COLD_FUNC CC_DONT_INLINE void assertion_failed(assertion_info const& info);
 
+CC_COLD_FUNC CC_DONT_INLINE bool is_debugger_connected();
+
 /// calls std::abort(), avoids includes
-[[noreturn]] CC_COLD_FUNC CC_DONT_INLINE void perform_abort();
+CC_COLD_FUNC CC_DONT_INLINE void perform_abort();
 }
 
 namespace cc

--- a/src/clean-core/assert.hh
+++ b/src/clean-core/assert.hh
@@ -15,15 +15,15 @@
 
 #ifdef CC_COMPILER_MSVC
 // __debugbreak() terminates immediately without an attached debugger
-#define CC_BREAK() (::cc::detail::is_debugger_connected() ? __debugbreak() : void(0))
+#define CC_DEBUG_BREAK() (::cc::detail::is_debugger_connected() ? __debugbreak() : void(0))
 #elif defined(CC_COMPILER_POSIX)
 // __builtin_trap() causes an illegal instruction and crashes without an attached debugger
-#define CC_BREAK() (::cc::detail::is_debugger_connected() ? __builtin_trap() : void(0))
+#define CC_DEBUG_BREAK() (::cc::detail::is_debugger_connected() ? __builtin_trap() : void(0))
 #else
-#define CC_BREAK() void(0)
+#define CC_DEBUG_BREAK() void(0)
 #endif
 
-#define CC_BREAK_AND_ABORT() (CC_BREAK(), ::cc::detail::perform_abort())
+#define CC_BREAK_AND_ABORT() (CC_DEBUG_BREAK(), ::cc::detail::perform_abort())
 
 // least overhead assertion macros
 // see https://godbolt.org/z/aWW1f8

--- a/src/clean-core/assertf.hh
+++ b/src/clean-core/assertf.hh
@@ -6,3 +6,5 @@
 
 // usage: CC_ASSERTF(a == b, "{} is not {}", a, b);
 #define CC_ASSERTF(cond, ...) CC_ASSERT_MSG(cond, ::cc::format(__VA_ARGS__).c_str())
+
+#define CC_RUNTIME_ASSERTF(cond, ...) CC_RUNTIME_ASSERT_MSG(cond, ::cc::format(__VA_ARGS__).c_str())

--- a/src/clean-core/bit_cast.hh
+++ b/src/clean-core/bit_cast.hh
@@ -8,7 +8,7 @@
 namespace cc
 {
 template <class To, class From>
-CC_FORCE_INLINE [[nodiscard]] To bit_cast(From const& src)
+[[nodiscard]] CC_FORCE_INLINE To bit_cast(From const& src)
 {
     static_assert(std::is_trivially_copyable_v<To>, "only supported for trivially copyable types");
     static_assert(std::is_trivially_copyable_v<From>, "only supported for trivially copyable types");

--- a/src/clean-core/bit_cast.hh
+++ b/src/clean-core/bit_cast.hh
@@ -3,10 +3,12 @@
 #include <cstring>
 #include <type_traits>
 
+#include <clean-core/macros.hh>
+
 namespace cc
 {
 template <class To, class From>
-[[nodiscard]] To bit_cast(From const& src)
+CC_FORCE_INLINE [[nodiscard]] To bit_cast(From const& src)
 {
     static_assert(std::is_trivially_copyable_v<To>, "only supported for trivially copyable types");
     static_assert(std::is_trivially_copyable_v<From>, "only supported for trivially copyable types");

--- a/src/clean-core/detail/lib/StackWalker.cc
+++ b/src/clean-core/detail/lib/StackWalker.cc
@@ -88,7 +88,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <tchar.h>
-#include <windows.h>
+#include <Windows.h>
 #pragma comment(lib, "version.lib") // for "VerQueryValue"
 #pragma warning(disable : 4826)
 

--- a/src/clean-core/detail/lib/StackWalker.hh
+++ b/src/clean-core/detail/lib/StackWalker.hh
@@ -45,7 +45,9 @@
 // so we need not to check the version (because we only support _MSC_VER >= 1100)!
 #pragma once
 
-#include <clean-core/native/win32_sanitized.hh>
+// windows headers are required here, but not included,
+// because headers beyond Windows.h are used in assert.cc and surrounded by the sanitize before/after.inl
+//#include <clean-core/native/win32_sanitized.hh>
 
 #if _MSC_VER >= 1900
 #pragma warning(disable : 4091)

--- a/src/clean-core/detail/lib/StackWalker.hh
+++ b/src/clean-core/detail/lib/StackWalker.hh
@@ -45,9 +45,7 @@
 // so we need not to check the version (because we only support _MSC_VER >= 1100)!
 #pragma once
 
-// windows headers are required here, but not included,
-// because headers beyond Windows.h are used in assert.cc and surrounded by the sanitize before/after.inl
-//#include <clean-core/native/win32_sanitized.hh>
+#include <Windows.h>
 
 #if _MSC_VER >= 1900
 #pragma warning(disable : 4091)

--- a/src/clean-core/from_string.hh
+++ b/src/clean-core/from_string.hh
@@ -1,30 +1,24 @@
 #pragma once
 
-#include <clean-core/string_view.hh>
+#include <clean-core/fwd.hh>
 
-/**
- * converts strings to primitive types
- *
- * returns true if the parsing was successful AND the whole string was consumed
- */
+// converts strings to primitive types
+// returns true on success
 
 namespace cc
 {
-[[nodiscard]] bool from_string(cc::string_view s, bool& v); // "true" or "false"
-[[nodiscard]] bool from_string(cc::string_view s, char& v);
+[[nodiscard]] bool from_string(cc::string_view str, bool& out_value); // str: "true" or "false"
+[[nodiscard]] bool from_string(cc::string_view str, char& out_value);
 
-[[nodiscard]] bool from_string(cc::string_view s, signed char& v);
-[[nodiscard]] bool from_string(cc::string_view s, signed short& v);
-[[nodiscard]] bool from_string(cc::string_view s, signed int& v);
-[[nodiscard]] bool from_string(cc::string_view s, signed long& v);
-[[nodiscard]] bool from_string(cc::string_view s, signed long long& v);
+[[nodiscard]] bool from_string(char const* c_str, int32& out_value);
+[[nodiscard]] bool from_string(char const* c_str, int64& out_value);
 
-[[nodiscard]] bool from_string(cc::string_view s, unsigned char& v);
-[[nodiscard]] bool from_string(cc::string_view s, unsigned short& v);
-[[nodiscard]] bool from_string(cc::string_view s, unsigned int& v);
-[[nodiscard]] bool from_string(cc::string_view s, unsigned long& v);
-[[nodiscard]] bool from_string(cc::string_view s, unsigned long long& v);
+[[nodiscard]] bool from_string(char const* c_str, float& out_value);
+[[nodiscard]] bool from_string(char const* c_str, double& out_value);
 
-[[nodiscard]] bool from_string(cc::string_view s, float& v);
-[[nodiscard]] bool from_string(cc::string_view s, double& v);
+[[nodiscard]] bool from_string(cc::string_view str, int32& out_value);
+[[nodiscard]] bool from_string(cc::string_view str, int64& out_value);
+
+[[nodiscard]] bool from_string(cc::string_view str, float& out_value);
+[[nodiscard]] bool from_string(cc::string_view str, double& out_value);
 }

--- a/src/clean-core/span.hh
+++ b/src/clean-core/span.hh
@@ -31,7 +31,7 @@ public:
 
     /// generic span constructor from contiguous_range
     /// CAUTION: container MUST outlive the span!
-    template <class Container, cc::enable_if<is_contiguous_range<Container, T>> = true>
+    template <class Container, cc::enable_if<is_contiguous_range<Container, T> && !std::is_same_v<std::decay_t<Container>, span>> = true>
     CC_FORCE_INLINE constexpr span(Container&& c) : _data(c.data()), _size(c.size())
     {
     }

--- a/src/clean-core/stringhash.hh
+++ b/src/clean-core/stringhash.hh
@@ -17,4 +17,19 @@ constexpr hash_t stringhash(char const* s)
     }
     return h;
 }
+
+constexpr hash_t stringhash_n(char const* s, int n)
+{
+    if (!s || n <= 0)
+        return 0;
+
+    hash_t h = hash_combine();
+    while (*s && n > 0)
+    {
+        h = hash_combine(h, hash_t(*s));
+        s++;
+        n--;
+    }
+    return h;
+}
 }

--- a/src/clean-core/threadsafe_allocators.hh
+++ b/src/clean-core/threadsafe_allocators.hh
@@ -137,6 +137,14 @@ struct atomic_linear_allocator final : allocator
     atomic_linear_allocator() = default;
     atomic_linear_allocator(span<byte> buffer) : _buffer_begin(buffer.data()), _offset(0), _buffer_end(buffer.data() + buffer.size()) {}
 
+    void initialize(span<byte> buffer)
+    {
+        // atomics cant be moved, making this necessary
+        _buffer_begin = buffer.data();
+        _offset = 0;
+        _buffer_end = buffer.data() + buffer.size();
+    }
+
 private:
     byte* _buffer_begin = nullptr;
     std::atomic<std::size_t> _offset = {0};

--- a/src/clean-core/tuple.hh
+++ b/src/clean-core/tuple.hh
@@ -13,6 +13,7 @@ namespace detail
 {
 template <class... Ts>
 struct tuple_impl;
+
 template <>
 struct tuple_impl<>
 {
@@ -22,6 +23,7 @@ struct tuple_impl<>
         static_assert(cc::always_false<I>, "cannot get element of empty tuple");
     }
 };
+
 template <class T>
 struct tuple_impl<T>
 {
@@ -43,6 +45,7 @@ struct tuple_impl<T>
         return value;
     }
 };
+
 template <class T, class U, class... Ts>
 struct tuple_impl<T, U, Ts...> : tuple_impl<U, Ts...>
 {

--- a/src/clean-core/utility.hh
+++ b/src/clean-core/utility.hh
@@ -95,6 +95,8 @@ template <class T>
 }
 
 /// increment the value (pointer or integer) to align at the given boundary
+/// use with ints: align_up(300, 16) = 304
+/// or with ptrs: align_up(0x5ACE, 256) = 0x5B00
 template <class T>
 [[nodiscard]] T align_up(T value, size_t alignment)
 {
@@ -102,6 +104,8 @@ template <class T>
 }
 
 /// decrement the value (pointer or integer) to align at the given boundary
+/// use with ints: align_down(300, 16) = 288
+/// or with ptrs: align_down(0x5ACE, 256) = 0x5A00
 template <class T>
 [[nodiscard]] T align_down(T value, size_t alignment)
 {

--- a/src/clean-core/utility.hh
+++ b/src/clean-core/utility.hh
@@ -87,11 +87,25 @@ template <class T>
     return (T)(((size_t)value + mask) & ~mask);
 }
 
+/// decrement the value (pointer or integer) to align to the given mask
+template <class T>
+[[nodiscard]] T align_down_masked(T value, size_t mask)
+{
+    return (T)((size_t)value & ~mask);
+}
+
 /// increment the value (pointer or integer) to align at the given boundary
 template <class T>
 [[nodiscard]] T align_up(T value, size_t alignment)
 {
     return align_up_masked(value, alignment - 1);
+}
+
+/// decrement the value (pointer or integer) to align at the given boundary
+template <class T>
+[[nodiscard]] T align_down(T value, size_t alignment)
+{
+    return align_down_masked(value, alignment - 1);
 }
 
 /// returns true if the value (pointer or integer) is aligned at the given boundary


### PR DESCRIPTION
- Improved assert behavior on Win32
    - Show CRT "Abort / Retry / Ignore" message _before_ debugbreaking
    - Only call __debugbreak() if a debugger is attached (__debugbreak() immediately terminates otherwise)
    - Throw a SEH exception instead of calling CRT abort (allows creating a crash dump for telemetry)
- utility.hh: add align_down
- span.hh: Prevent the templated ctor from being called for span-to-span copies (this is very annoying during debugging otherwise)
- assert.hh: add `CC_BREAK()` macro for separate usage
- assertf.hh: add `CC_RUNTIME_ASSERTF()`
- Rework from_string implementation to be more efficient and concise, overload on sized integer types, remove sub-32bit overloads
- Add stringhash_n