### PR TITLE
Fix memory bug in capped_array constructor

### DIFF
--- a/src/clean-core/alloc_array.hh
+++ b/src/clean-core/alloc_array.hh
@@ -105,8 +105,12 @@ struct alloc_array
         if (new_size > 0)
         {
             _data = _alloc(new_size);
-            for (size_t i = 0; i < new_size; ++i)
-                new (placement_new, &_data[i]) T();
+
+            if constexpr (!std::is_trivially_constructible_v<T>)
+            {
+                for (size_t i = 0; i < new_size; ++i)
+                    new (placement_new, &_data[i]) T();
+            }
         }
         else
         {

--- a/src/clean-core/capped_array.hh
+++ b/src/clean-core/capped_array.hh
@@ -54,7 +54,15 @@ public:
     constexpr capped_array(size_t size) : _size(compact_size_t(size))
     {
         CC_CONTRACT(size <= N);
-        new (placement_new, &_u.value[0]) T[size]();
+
+        if constexpr (!std::is_trivially_constructible_v<T>)
+        {
+            // NOTE: DO NOT use array-placement new!
+            // it stores the array size in the first 8 bytes
+            // (at least on MSVC, the standard simply allows a padding on the return value)
+            for (compact_size_t i = 0; i < _size; ++i)
+                new (placement_new, &_u.value[i]) T();
+        }
     }
 
     constexpr capped_array(std::initializer_list<T> data)
@@ -72,7 +80,16 @@ public:
         CC_CONTRACT(size <= N);
         capped_array a;
         a._size = static_cast<compact_size_t>(size);
-        new (&a._u.value[0]) T[size];
+
+        if constexpr (!std::is_trivially_constructible_v<T>)
+        {
+            // NOTE: DO NOT use array-placement new!
+            // it stores the array size in the first 8 bytes
+            // (at least on MSVC, the standard simply allows a padding on the return value)
+            for (compact_size_t i = 0; i < _size; ++i)
+                new (placement_new, &_u.value[i]) T;
+        }
+
         return a;
     }
 

--- a/src/clean-core/capped_array.hh
+++ b/src/clean-core/capped_array.hh
@@ -80,16 +80,7 @@ public:
         CC_CONTRACT(size <= N);
         capped_array a;
         a._size = static_cast<compact_size_t>(size);
-
-        if constexpr (!std::is_trivially_constructible_v<T>)
-        {
-            // NOTE: DO NOT use array-placement new!
-            // it stores the array size in the first 8 bytes
-            // (at least on MSVC, the standard simply allows a padding on the return value)
-            for (compact_size_t i = 0; i < _size; ++i)
-                new (placement_new, &_u.value[i]) T;
-        }
-
+        // no ctors called
         return a;
     }
 


### PR DESCRIPTION
capped_array previously used placement new with an array type, causing default ctors to be called with an 8 byte offset per element, as well as a buffer overrun for the last one