### PR TITLE
Reciprocal square root intrinsics, cc::array fixes

### DIFF
--- a/src/clean-core/allocator.hh
+++ b/src/clean-core/allocator.hh
@@ -117,6 +117,8 @@ struct linear_allocator final : allocator
     size_t max_size() const { return _buffer_end - _buffer_begin; }
     float allocated_ratio() const { return allocated_size() / float(max_size()); }
 
+    std::byte* buffer() const { return _buffer_begin; }
+
     linear_allocator() = default;
     linear_allocator(span<std::byte> buffer) : _buffer_begin(buffer.data()), _head(buffer.data()), _buffer_end(buffer.data() + buffer.size()) {}
 

--- a/src/clean-core/array.hh
+++ b/src/clean-core/array.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 
 #include <initializer_list>
 #include <utility> // for tuple_size
@@ -101,6 +102,10 @@ struct array<T, dynamic_size>
         {
             for (size_t i = 0; i < size; ++i)
                 new (placement_new, &this->_data[i]) T();
+        }
+        else
+        {
+            std::memset(_data, 0, _size * sizeof(T));
         }
     }
 

--- a/src/clean-core/array.hh
+++ b/src/clean-core/array.hh
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <cstdint>
-#include <cstdlib>
 
 #include <initializer_list>
 #include <utility> // for tuple_size
 
+#include <clean-core/allocator.hh>
 #include <clean-core/always_false.hh>
 #include <clean-core/assert.hh>
 #include <clean-core/detail/container_impl_util.hh>
@@ -226,8 +226,8 @@ struct array<T, dynamic_size>
     }
 
 private:
-    T* _alloc(size_t size) { return reinterpret_cast<T*>(std::malloc(size * sizeof(T))); }
-    void _free(T* p) { std::free(p); }
+    T* _alloc(size_t size) { return reinterpret_cast<T*>(cc::system_allocator->alloc(size * sizeof(T), alignof(T))); }
+    void _free(T* p) { cc::system_allocator->free(p); }
 
     void _destroy()
     {

--- a/src/clean-core/array.hh
+++ b/src/clean-core/array.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
 
 #include <initializer_list>
 #include <utility> // for tuple_size
@@ -87,14 +88,20 @@ struct array
 template <class T>
 struct array<T, dynamic_size>
 {
-    static_assert(sizeof(T) > 0, "cannot make array of incomplete object");
-
-    array() = default;
+    array() { static_assert(sizeof(T) > 0, "cannot make array of incomplete object"); }
 
     explicit array(size_t size)
     {
+        static_assert(sizeof(T) > 0, "cannot make array of incomplete object");
+
         _size = size;
-        _data = new T[_size](); // default ctor!
+        _data = _alloc(size);
+
+        if constexpr (!std::is_trivially_constructible_v<T>)
+        {
+            for (size_t i = 0; i < size; ++i)
+                new (placement_new, &this->_data[i]) T();
+        }
     }
 
     [[nodiscard]] static array defaulted(size_t size) { return array(size); }
@@ -103,7 +110,7 @@ struct array<T, dynamic_size>
     {
         array a;
         a._size = size;
-        a._data = new T[size];
+        a._data = a._alloc(a._size);
         return a;
     }
 
@@ -111,37 +118,37 @@ struct array<T, dynamic_size>
     {
         array a;
         a._size = size;
-        a._data = new T[size];
+        a._data = a._alloc(a._size);
         detail::container_copy_construct_fill(value, size, a._data);
         return a;
     }
 
     void resize(size_t new_size, T const& value = {})
     {
-        delete[] _data;
+        _destroy();
         _size = new_size;
-        _data = new T[new_size];
+        _data = _alloc(_size);
         detail::container_copy_construct_fill(value, _size, _data);
     }
 
     array(std::initializer_list<T> data)
     {
         _size = data.size();
-        _data = new T[_size];
+        _data = _alloc(_size);
         detail::container_copy_construct_range<T>(data.begin(), _size, _data);
     }
 
     array(span<T const> data)
     {
         _size = data.size();
-        _data = new T[_size];
+        _data = _alloc(_size);
         detail::container_copy_construct_range<T>(data.data(), _size, _data);
     }
 
     array(array const& a)
     {
         _size = a._size;
-        _data = new T[a._size];
+        _data = _alloc(_size);
         detail::container_copy_construct_range<T>(a.data(), _size, _data);
     }
     array(array&& a) noexcept
@@ -155,23 +162,27 @@ struct array<T, dynamic_size>
     {
         if (&a != this)
         {
-            delete[] _data;
+            _destroy();
             _size = a._size;
-            _data = new T[a._size];
+            _data = _alloc(_size);
             detail::container_copy_construct_range<T>(a.data(), _size, _data);
         }
         return *this;
     }
     array& operator=(array&& a) noexcept
     {
-        delete[] _data;
+        _destroy();
         _data = a._data;
         _size = a._size;
         a._data = nullptr;
         a._size = 0;
         return *this;
     }
-    ~array() { delete[] _data; }
+    ~array()
+    {
+        static_assert(sizeof(T) > 0, "array destructor requires complete type");
+        _destroy();
+    }
 
     constexpr T* begin() { return _data; }
     constexpr T* end() { return _data + _size; }
@@ -215,13 +226,23 @@ struct array<T, dynamic_size>
     }
 
 private:
+    T* _alloc(size_t size) { return reinterpret_cast<T*>(std::malloc(size * sizeof(T))); }
+    void _free(T* p) { std::free(p); }
+
+    void _destroy()
+    {
+        detail::container_destroy_reverse<T>(_data, _size);
+        _free(_data);
+    }
+
+private:
     T* _data = nullptr;
     size_t _size = 0;
 };
 
 // deduction guides
 template <class T, class... U>
-array(T, U...)->array<T, 1 + sizeof...(U)>;
+array(T, U...) -> array<T, 1 + sizeof...(U)>;
 
 template <class T, class... Args>
 [[nodiscard]] array<T, 1 + sizeof...(Args)> make_array(T&& v0, Args&&... rest)

--- a/src/clean-core/intrinsics.hh
+++ b/src/clean-core/intrinsics.hh
@@ -60,6 +60,17 @@ CC_FORCE_INLINE int64_t intrin_atomic_add(int64_t volatile* counter, int64_t val
 #endif
 }
 
+// approximate inverse square root
+CC_FORCE_INLINE float intrin_rsqrt(float x)
+{
+    // comparisons vs 1.f/sqrt(x) and carmack:
+    // https://godbolt.org/z/GhxG6fo3j
+    // https://quick-bench.com/q/_YlmyvyGpu4zb9lavwzsDy8VqWk
+    __m128 temp = _mm_set_ss(x);
+    temp = _mm_rsqrt_ss(temp);
+    return _mm_cvtss_f32(temp);
+}
+
 inline bool test_cpuid_register(int level, int register_index, int bit_index)
 {
 #ifdef CC_COMPILER_MSVC

--- a/src/clean-core/intrinsics.hh
+++ b/src/clean-core/intrinsics.hh
@@ -71,55 +71,54 @@ CC_FORCE_INLINE float intrin_rsqrt(float x)
     // performance and codegen vs full computation:
     // https://godbolt.org/z/GhxG6fo3j https://quick-bench.com/q/_YlmyvyGpu4zb9lavwzsDy8VqWk
 
-    __m128 temp = _mm_set_ss(x);
-    temp = _mm_rsqrt_ss(temp);
-    return _mm_cvtss_f32(temp);
+    __m128 val = _mm_set_ss(x);
+    val = _mm_rsqrt_ss(val);
+    return _mm_cvtss_f32(val);
 }
 
 // approximate inverse square root with one Newton-Raphson iteration
 // about 2.5x faster than 1.f / std::sqrt(x)
 CC_FORCE_INLINE float intrin_rsqrt_nr1(float x)
 {
-    const __m128 const_one_half = _mm_set_ss(0.5f);
-    __m128 y_0, x_0, x_1, x_half;
-    float temp;
-    y_0 = _mm_set_ss(x);
-    x_0 = _mm_rsqrt_ss(y_0);
-    x_half = _mm_mul_ss(y_0, const_one_half);
+    __m128 const point_five = _mm_set_ss(0.5f);
+    __m128 y_0 = _mm_set_ss(x);
+    __m128 x_0 = _mm_rsqrt_ss(y_0);
+    __m128 x_half = _mm_mul_ss(y_0, point_five);
 
     // doing the following in SSE regs as well gives slightly better codegen
     // Newton-Raphson iteration
-    x_1 = _mm_mul_ss(x_0, x_0);
-    x_1 = _mm_sub_ss(const_one_half, _mm_mul_ss(x_half, x_1));
+    __m128 x_1 = _mm_mul_ss(x_0, x_0);
+    x_1 = _mm_sub_ss(point_five, _mm_mul_ss(x_half, x_1));
     x_1 = _mm_add_ss(x_0, _mm_mul_ss(x_0, x_1));
-    _mm_store_ss(&temp, x_1);
-    return temp;
+
+    float res;
+    _mm_store_ss(&res, x_1);
+    return res;
 }
 
 // approximate inverse square root with two Newton-Raphson iterations
 // about 1.5x faster than 1.f / std::sqrt(x)
 CC_FORCE_INLINE float intrin_rsqrt_nr2(float x)
 {
-    const __m128 const_one_half = _mm_set_ss(0.5f);
-    __m128 y_0, x_0, x_1, x_2, x_half;
-    float temp;
-    y_0 = _mm_set_ss(x);
-    x_0 = _mm_rsqrt_ss(y_0);
-    x_half = _mm_mul_ss(y_0, const_one_half);
+    __m128 const point_five = _mm_set_ss(0.5f);
+    __m128 y_0 = _mm_set_ss(x);
+    __m128 x_0 = _mm_rsqrt_ss(y_0);
+    __m128 x_half = _mm_mul_ss(y_0, point_five);
 
     // doing the following in SSE regs as well gives slightly better codegen
     // Newton-Raphson iteration 1
-    x_1 = _mm_mul_ss(x_0, x_0);
-    x_1 = _mm_sub_ss(const_one_half, _mm_mul_ss(x_half, x_1));
+    __m128 x_1 = _mm_mul_ss(x_0, x_0);
+    x_1 = _mm_sub_ss(point_five, _mm_mul_ss(x_half, x_1));
     x_1 = _mm_add_ss(x_0, _mm_mul_ss(x_0, x_1));
 
     // Newton-Raphson iteration 2
-    x_2 = _mm_mul_ss(x_1, x_1);
-    x_2 = _mm_sub_ss(const_one_half, _mm_mul_ss(x_half, x_2));
+    __m128 x_2 = _mm_mul_ss(x_1, x_1);
+    x_2 = _mm_sub_ss(point_five, _mm_mul_ss(x_half, x_2));
     x_2 = _mm_add_ss(x_1, _mm_mul_ss(x_1, x_2));
 
-    _mm_store_ss(&temp, x_2);
-    return temp;
+    float res;
+    _mm_store_ss(&res, x_2);
+    return res;
 }
 
 inline bool test_cpuid_register(int level, int register_index, int bit_index)

--- a/src/clean-core/intrinsics.hh
+++ b/src/clean-core/intrinsics.hh
@@ -64,8 +64,7 @@ CC_FORCE_INLINE int64_t intrin_atomic_add(int64_t volatile* counter, int64_t val
 CC_FORCE_INLINE float intrin_rsqrt(float x)
 {
     // comparisons vs 1.f/sqrt(x) and carmack:
-    // https://godbolt.org/z/GhxG6fo3j
-    // https://quick-bench.com/q/_YlmyvyGpu4zb9lavwzsDy8VqWk
+    // https://godbolt.org/z/GhxG6fo3j https://quick-bench.com/q/_YlmyvyGpu4zb9lavwzsDy8VqWk
     __m128 temp = _mm_set_ss(x);
     temp = _mm_rsqrt_ss(temp);
     return _mm_cvtss_f32(temp);


### PR DESCRIPTION
- Add rsqrtss intrinsic functions to intrinsics.hh
    - Add variants with one and two Newton-Raphson iterations for more precision
- Use cc::system_allocator over new/delete in cc::array, fix ctor calls
- Minor change