### PR TITLE
Pt/develop

### DIFF
--- a/src/clean-core/always_false.hh
+++ b/src/clean-core/always_false.hh
@@ -7,4 +7,8 @@ namespace cc
 ///   static_assert(cc::always_false<T>, "some error");
 template <class... E>
 constexpr bool always_false = false;
+
+/// same as always_false, but for non-type template parameters, e.g. always_false_v<Dimension>
+template <auto... E>
+constexpr bool always_false_v = false;
 }

--- a/src/clean-core/bits.hh
+++ b/src/clean-core/bits.hh
@@ -135,8 +135,8 @@ inline uint32_t bit_log2(uint32_t v) { return uint32_t(8 * sizeof(uint32_t) - co
 inline uint64_t bit_log2(uint64_t v) { return uint64_t(8 * sizeof(uint64_t) - count_leading_zeros(v) - 1); }
 
 // ceils to the nearest power of 2
-inline uint32_t ceil_pow2(uint32_t v) { return uint32_t(1) << (bit_log2(v - uint32_t(1)) + 1); }
-inline uint64_t ceil_pow2(uint64_t v) { return uint64_t(1) << (bit_log2(v - uint64_t(1)) + 1); }
+inline uint32_t ceil_pow2(uint32_t v) { return uint32_t(1) << ((bit_log2(v - uint32_t(1)) + 1) & 31); }
+inline uint64_t ceil_pow2(uint64_t v) { return uint64_t(1) << ((bit_log2(v - uint64_t(1)) + 1) & 63); }
 
 // returns true if v is a power of 2
 constexpr bool is_pow2(uint32_t v) { return ((v & (v - uint32_t(1))) == 0); }

--- a/src/clean-core/capped_array.hh
+++ b/src/clean-core/capped_array.hh
@@ -55,14 +55,13 @@ public:
     {
         CC_CONTRACT(size <= N);
 
-        if constexpr (!std::is_trivially_constructible_v<T>)
-        {
-            // NOTE: DO NOT use array-placement new!
-            // it stores the array size in the first 8 bytes
-            // (at least on MSVC, the standard simply allows a padding on the return value)
-            for (compact_size_t i = 0; i < _size; ++i)
-                new (placement_new, &_u.value[i]) T();
-        }
+        // NOTE: DO NOT use array-placement new!
+        //       it stores the array size in the first 8 bytes
+        //       (at least on MSVC, the standard simply allows a padding on the return value)
+        // NOTE: default constructor default-initializes all members
+        //       if the overhead is too big, use capped_array::uninitialized
+        for (compact_size_t i = 0; i < _size; ++i)
+            new (placement_new, &_u.value[i]) T();
     }
 
     constexpr capped_array(std::initializer_list<T> data)
@@ -95,7 +94,7 @@ public:
     }
 
     template <class... Args>
-    void emplace(size_t new_size, Args&&... init_args)
+    void emplace(size_t new_size, Args && ... init_args)
     {
         CC_CONTRACT(new_size <= N);
 
@@ -111,7 +110,7 @@ public:
     {
         detail::container_copy_construct_range<T, compact_size_t>(&rhs._u.value[0], _size, &_u.value[0]);
     }
-    capped_array(capped_array&& rhs) noexcept : _size(rhs._size)
+    capped_array(capped_array && rhs) noexcept : _size(rhs._size)
     {
         detail::container_move_construct_range<T, compact_size_t>(&rhs._u.value[0], _size, &_u.value[0]);
         rhs._size = 0;

--- a/src/clean-core/capped_array.hh
+++ b/src/clean-core/capped_array.hh
@@ -59,6 +59,7 @@ public:
         //       it stores the array size in the first 8 bytes
         //       (at least on MSVC, the standard simply allows a padding on the return value)
         // NOTE: default constructor default-initializes all members
+        //       this means zero-init if no user ctor is provided
         //       if the overhead is too big, use capped_array::uninitialized
         for (compact_size_t i = 0; i < _size; ++i)
             new (placement_new, &_u.value[i]) T();

--- a/src/clean-core/detail/compact_size_t.hh
+++ b/src/clean-core/detail/compact_size_t.hh
@@ -33,7 +33,7 @@ using compact_size_t_typed = compact_size_t_for<N, alignof(T)>;
 template <size_t bits>
 struct compact_size_t_by_bits_impl
 {
-    static_assert(always_false<bits>, "bit size not supported");
+    static_assert(always_false_v<bits>, "bit size not supported");
 };
 template <>
 struct compact_size_t_by_bits_impl<8>

--- a/src/clean-core/tuple.hh
+++ b/src/clean-core/tuple.hh
@@ -20,7 +20,7 @@ struct tuple_impl<>
     template <size_t I>
     constexpr void get() const
     {
-        static_assert(cc::always_false<I>, "cannot get element of empty tuple");
+        static_assert(cc::always_false_v<I>, "cannot get element of empty tuple");
     }
 };
 


### PR DESCRIPTION
* added always_false_v
* changed order of pow2 masking (a bit more natural to read and I fixed it on my branch as well :D )
* fixed capped_array regression (default ctor should default-init)
* fixed span template errors

NOTE: clang-format 9 is our current reference and it does some weird things in capped_array