### PR TITLE
Pt/map emplace f

### DIFF
--- a/src/clean-core/map.hh
+++ b/src/clean-core/map.hh
@@ -126,6 +126,29 @@ public:
         return l.emplace_front(KeyT(key)).value;
     }
 
+    /// looks up the given key
+    /// if it does not exists, creates it via "create()"
+    /// ("create()" must return something that can construct T)
+    /// returns the value in either case
+    /// NOTE: create must not modify this map
+    ///       during create, the old size is still valid
+    template <class T = KeyT, class CreateF>
+    ValueT& emplace_f(T const& key, CreateF&& create)
+    {
+        if (_entries.empty() || _size > _entries.size())
+            reserve(_size == 0 ? 4 : _size + 1);
+
+        auto idx = this->_get_location(key);
+        auto& l = _entries[idx];
+        for (auto& e : l)
+            if (EqualT{}(e.key, key))
+                return e.value;
+
+        auto& val = l.emplace_front(KeyT(key), create()).value;
+        ++_size; // AFTER create
+        return val;
+    }
+
     /// looks up the given key and returns the element
     /// UB if key is not present
     template <class T = KeyT>

--- a/src/clean-core/map.hh
+++ b/src/clean-core/map.hh
@@ -133,7 +133,7 @@ public:
     /// NOTE: create must not modify this map
     ///       during create, the old size is still valid
     template <class T = KeyT, class CreateF>
-    ValueT& emplace_f(T const& key, CreateF&& create)
+    ValueT& get_or_create(T const& key, CreateF&& create)
     {
         if (_entries.empty() || _size > _entries.size())
             reserve(_size == 0 ? 4 : _size + 1);

--- a/tests/vector.cc
+++ b/tests/vector.cc
@@ -259,14 +259,14 @@ MONTE_CARLO_TEST("cc::vector mct")
     addOp("gen int", make_int);
     addOp("gen str", make_str);
 
-    auto constexpr max_size = 40;
+    static auto constexpr max_size = 40;
     auto const addType = [&](auto obj, auto make_element, auto elem_str, auto elem_pred)
     {
         using vector_t = decltype(obj);
         using T = std::decay_t<decltype(obj[0])>;
 
-        auto constexpr is_std_vec = is_std_vector<vector_t>::value;
-        auto constexpr is_capped_vec = is_capped_vector<vector_t>::value;
+        static auto constexpr is_std_vec = is_std_vector<vector_t>::value;
+        static auto constexpr is_capped_vec = is_capped_vector<vector_t>::value;
 
         auto is_empty = [](vector_t const& s) { return s.empty(); };
 


### PR DESCRIPTION
map lookups are kinda expensive and we often have caching logic of the form "if the key is already there, give me the value. otherwise, do some init code, produce a value for that key, add it to the map and return it".