### PR TITLE
Pt/generalized format

### DIFF
--- a/src/clean-core/error_messages.cc
+++ b/src/clean-core/error_messages.cc
@@ -1,0 +1,203 @@
+#include "error_messages.hh"
+
+#include <clean-core/vector.hh>
+
+cc::string cc::make_error_message_for_substrings(string_view str, std::initializer_list<substr_error> errors, string_view message)
+{
+    for (auto const& e : errors)
+        CC_ASSERT(str.begin() <= e.target.begin() && e.target.end() <= str.end() && "error targets must be substrings of input string");
+
+    cc::string res;
+
+    // TODO: this could be made more efficient
+    // TODO: colors
+    // TODO: should multiline errors be repeated?
+    // TODO: configurable delimiters
+
+    struct err_info
+    {
+        substr_error err;
+
+        int marker_offset = 0; // how many lines the marked is moved down
+        int marker_start = 0;
+        int marker_end = 0; // exclusive
+
+        int text_offset = 0; // how many lines the text is moved down
+        int text_start = 0;
+        int text_end = 0; // exclusive
+
+        bool overlaps_marker(err_info const& r) const
+        {
+            if (r.marker_end < marker_start - 1)
+                return false;
+            if (r.marker_start > marker_end)
+                return false;
+            return true;
+        }
+        bool overlaps_text(err_info const& r) const
+        {
+            if (r.text_end < text_start - 1)
+                return false;
+            if (r.text_start > text_end)
+                return false;
+            return true;
+        }
+    };
+
+    // special case for empty string
+    if (str.empty())
+    {
+        res += "<empty string>";
+        for (auto const& e : errors)
+        {
+            res += "\n* ";
+            res += e.message;
+        }
+    }
+    else
+    {
+        cc::vector<err_info> errs;
+        cc::vector<cc::string> err_lines;
+
+        // build result line-by-line
+        auto first_line = true;
+        for (auto line : str.split('\n'))
+        {
+            // add line to output
+            if (first_line)
+                first_line = false;
+            else
+                res += "\n";
+            res += "> ";
+            res += line;
+
+            // prepare errors
+            errs.clear();
+            int total_marker_lines = 0;
+            int total_text_lines = 0;
+            int max_line_size = 0;
+            for (auto const& e : errors)
+            {
+                auto marker_start = e.target.begin() - line.begin();
+                auto marker_end = e.target.end() - line.begin(); // exclusive
+                if (marker_start == marker_end)
+                    marker_end++;
+
+                if (marker_end <= 0)
+                    continue; // earlier line
+
+                if (marker_start > int64_t(line.size()))
+                    continue; // not this line
+                // contains line.size as special case so that \n can be marked
+
+                err_info err;
+                err.err = e;
+                err.marker_start = marker_start;
+                err.marker_end = marker_end;
+                err.text_start = (marker_start + marker_end - 1) / 2;
+                err.text_end = err.text_start + e.message.size() + 2;
+
+                // allocate marker
+                while (true)
+                {
+                    auto overlaps = false;
+                    for (auto const& ee : errs)
+                        if (ee.marker_offset == err.marker_offset && ee.overlaps_marker(err))
+                        {
+                            overlaps = true;
+                            break;
+                        }
+
+                    if (!overlaps)
+                        break;
+
+                    err.marker_offset++;
+                }
+
+                // allocate text
+                while (true)
+                {
+                    auto overlaps = false;
+                    for (auto const& ee : errs)
+                        if (ee.text_offset == err.text_offset && ee.overlaps_text(err))
+                        {
+                            overlaps = true;
+                            break;
+                        }
+
+                    if (!overlaps)
+                        break;
+
+                    err.text_offset++;
+                }
+
+                total_marker_lines = cc::max(total_marker_lines, err.marker_offset + 1);
+                total_text_lines = cc::max(total_text_lines, err.text_offset + 1);
+
+                max_line_size = cc::max(max_line_size, err.marker_end);
+                max_line_size = cc::max(max_line_size, err.text_end);
+
+                errs.push_back(err);
+            }
+
+            // create error text
+            if (!errs.empty())
+            {
+                err_lines.resize(total_marker_lines + total_text_lines);
+                for (auto& s : err_lines)
+                {
+                    s.clear();
+                    s.resize(max_line_size, ' ');
+                }
+
+                // connectors
+                for (auto const& e : errs)
+                {
+                    auto x = e.text_start;
+                    auto y0 = e.marker_offset + 1;
+                    auto y1 = total_marker_lines + e.text_offset - 1;
+                    for (auto y = y0; y <= y1; ++y)
+                        err_lines[y][x] = '|';
+                }
+
+                // markers
+                for (auto const& e : errs)
+                {
+                    auto x0 = e.marker_start;
+                    auto x1 = e.marker_end;
+                    auto y = e.marker_offset;
+                    for (auto x = x0; x < x1; ++x)
+                        err_lines[y][x] = '^';
+                }
+
+                // text
+                for (auto const& e : errs)
+                {
+                    auto x = e.text_start;
+                    auto y = total_marker_lines + e.text_offset;
+                    err_lines[y][x++] = '*';
+                    err_lines[y][x++] = ' ';
+                    for (auto c : e.err.message)
+                        err_lines[y][x++] = c;
+                }
+
+                // add lines to result
+                for (auto const& l : err_lines)
+                {
+                    res += "\n";
+                    res += "  "; // for "> "
+                    res += l;
+                }
+            }
+        }
+    }
+
+    // append optional message
+    if (!message.empty())
+    {
+        res += "\n";
+        res += message;
+    }
+
+    return res;
+}

--- a/src/clean-core/error_messages.hh
+++ b/src/clean-core/error_messages.hh
@@ -24,6 +24,19 @@ struct substr_error
 
 /// creates an ASCII-art error message for 'str'
 /// does NOT have a trailing \n
+///
+/// Example from cc::format:
+///
+///   make_error_message_for_substrings(fmt_str, {{curr_c, "expected '}' (or missing earlier '{')"}})
+///
+///   called in the erroneous call 'cc::format("{2} - 0} = {1}", 1, 2, 3)'
+///
+///   produces:
+///
+///     > {2} - 0} = {1}
+///               ^
+///               * expected '}' (or missing earlier '{')
+///
 cc::string make_error_message_for_substrings(cc::string_view str, std::initializer_list<substr_error> errors, cc::string_view message = "");
 
 }

--- a/src/clean-core/error_messages.hh
+++ b/src/clean-core/error_messages.hh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <initializer_list>
+
+#include <clean-core/string.hh>
+#include <clean-core/string_view.hh>
+
+//
+// this header contains helper for constructing pleasing error messages
+//
+
+namespace cc
+{
+
+struct substr_error
+{
+    cc::string_view target; // can be zero-sized to indicate the space between two chars
+    cc::string_view message;
+
+    substr_error() = default;
+    substr_error(cc::string_view target, cc::string_view message) : target(target), message(message) {}
+    substr_error(char const* target, cc::string_view message) : target(target, size_t(0)), message(message) {}
+};
+
+/// creates an ASCII-art error message for 'str'
+/// does NOT have a trailing \n
+cc::string make_error_message_for_substrings(cc::string_view str, std::initializer_list<substr_error> errors, cc::string_view message = "");
+
+}

--- a/src/clean-core/format.cc
+++ b/src/clean-core/format.cc
@@ -8,6 +8,112 @@
 
 namespace cc::detail
 {
+static void advance_printf_chars(cc::string_view fmt_str, char const*& curr, char const* end)
+{
+    // taken from https://en.cppreference.com/w/cpp/io/c/fprintf
+
+    // [optional] one or more flags that modify the behavior of the conversion
+    while (curr != end
+           && (*curr == '-' || //
+               *curr == '+' || //
+               *curr == ' ' || //
+               *curr == '-' || //
+               *curr == '#' || //
+               *curr == '0'))
+        ++curr;
+
+    // [optional] integer value or * that specifies minimum field width
+    // NOTE: we do not really support * yet
+    if (curr != end)
+    {
+        if (*curr == '*')
+            ++curr;
+        else
+        {
+            while (curr != end && cc::is_digit(*curr))
+                ++curr;
+        }
+    }
+
+    // [optional] . followed by integer number or *
+    // NOTE: we do not really support * yet
+    if (curr != end)
+    {
+        if (*curr == '.')
+        {
+            ++curr;
+            CC_ASSERT_ERRMSG(curr != end, fmt_str, {{curr, "expected number or '*'"}});
+
+            if (*curr == '*')
+                ++curr;
+            else
+            {
+                CC_ASSERT_ERRMSG(cc::is_digit(*curr), fmt_str, {{curr, "expected number or '*'"}});
+                while (curr != end && cc::is_digit(*curr))
+                    ++curr;
+            }
+        }
+    }
+
+    // [optional] length modifier
+    if (curr != end)
+    {
+        switch (*curr)
+        {
+        case 'z':
+        case 't':
+        case 'j':
+        case 'L':
+            ++curr;
+            break;
+
+        case 'h':
+            ++curr;
+            if (curr != end && *curr == 'h') // hh
+                ++curr;
+            break;
+
+        case 'l':
+            ++curr;
+            if (curr != end && *curr == 'l') // ll
+                ++curr;
+            break;
+        }
+    }
+
+    // conversion format specifier
+    switch (*curr)
+    {
+    case 'c':
+    case 's':
+    case 'd':
+    case 'i':
+    case 'o':
+    case 'x':
+    case 'X':
+    case 'u':
+    case 'f':
+    case 'F':
+    case 'e':
+    case 'E':
+    case 'a':
+    case 'A':
+    case 'g':
+    case 'G':
+    case 'p':
+        ++curr;
+        break;
+
+    case 'n':
+        CC_ASSERT_ERRMSG(false, fmt_str, {{curr, "conversion format specifier '%n' not supported"}});
+        break;
+
+    default:
+        CC_ASSERT_ERRMSG(false, fmt_str, {{curr, "conversion format specifier not supported"}});
+        break;
+    }
+}
+
 template <bool support_printf, bool support_pythonic>
 static void impl_vformat_to(cc::stream_ref<char> ss, cc::string_view fmt_str, cc::span<default_do_format::arg_info> args)
 {
@@ -24,6 +130,46 @@ static void impl_vformat_to(cc::stream_ref<char> ss, cc::string_view fmt_str, cc
     {
         if (curr_c == end_c)
             break; // done
+
+        if (support_printf && *curr_c == '%')
+        {
+            auto const arg_start_c = curr_c;
+
+            // append segment in any case
+            if (segment_start != curr_c)
+                ss << cc::string_view(segment_start, curr_c);
+
+            ++curr_c;
+            CC_ASSERT_ERRMSG(curr_c != end_c, fmt_str, {{curr_c, "expected format specifier or '%'"}});
+
+            if (*curr_c == '%') // escaped %
+            {
+                segment_start = curr_c; // '%' belongs to next segment
+                ++curr_c;
+                continue;
+            }
+
+            // collect format
+            auto const fmt_start = curr_c;
+            advance_printf_chars(fmt_str, curr_c, end_c); // curr_c points _behind_ fmt
+            CC_ASSERT_ERRMSG(fmt_start != curr_c, fmt_str, {{curr_c, "expected format specifier or '%'"}});
+            CC_ASSERT_ERRMSG(curr_arg_id >= 0, fmt_str, {{{arg_start_c, curr_c}, "cannot use % args after named or indexed argument"}});
+            CC_ASSERT_ERRMSG(curr_arg_id < int(args.size()), fmt_str, {{{arg_start_c, curr_c}, "not enough arguments passed to cc::format"}});
+
+            // post-process format
+            auto fmt_spec = cc::string_view(fmt_start, curr_c);
+            if (fmt_spec == 's')
+                fmt_spec = {}; // %s is the universal to_string
+
+            // add arg
+            args[curr_arg_id].do_format(ss, args[curr_arg_id].data, fmt_spec);
+            args[curr_arg_id].was_used = true;
+            ++curr_arg_id;
+
+            // start next segment
+            segment_start = curr_c;
+            continue;
+        }
 
         // } must belong to }} here
         if (support_pythonic && *curr_c == '}')
@@ -127,7 +273,7 @@ static void impl_vformat_to(cc::stream_ref<char> ss, cc::string_view fmt_str, cc
                     ++curr_c;
                     CC_ASSERT_ERRMSG(curr_c != end_c, fmt_str, {{{arg_start_c, curr_c}, "missing closing '}'"}});
 
-                    auto const args_start = curr_c;
+                    auto const fmt_start = curr_c;
                     while (*curr_c != '}')
                     {
                         ++curr_c;
@@ -135,7 +281,7 @@ static void impl_vformat_to(cc::stream_ref<char> ss, cc::string_view fmt_str, cc
                     }
 
                     // TODO: handle arguments that themselves contain args
-                    args[argument_index].do_format(ss, args[argument_index].data, cc::string_view(args_start, curr_c));
+                    args[argument_index].do_format(ss, args[argument_index].data, cc::string_view(fmt_start, curr_c));
                     args[argument_index].was_used = true;
                 }
             }

--- a/src/clean-core/format.cc
+++ b/src/clean-core/format.cc
@@ -1,120 +1,180 @@
 #include "format.hh"
 
+#include <clean-core/assertf.hh>
 #include <clean-core/char_predicates.hh>
+#include <clean-core/error_messages.hh>
 
-void cc::detail::vformat_to(cc::stream_ref<char> ss, cc::string_view fmt_str, cc::span<arg_info const> args)
+#define CC_ASSERT_ERRMSG(cond, ...) CC_ASSERTF(cond, "{}", cc::make_error_message_for_substrings(__VA_ARGS__))
+
+namespace cc::detail
+{
+template <bool support_printf, bool support_pythonic>
+static void impl_vformat_to(cc::stream_ref<char> ss, cc::string_view fmt_str, cc::span<default_do_format::arg_info> args)
 {
     // index of the next argument
-    // Cannot be used after a named or numbered arg was encountered: -1 == invalid
-    int arg_id = 0;
+    // cannot be used after a named or numbered arg was encountered: -1 == invalid
+    int curr_arg_id = 0;
 
-    // each iteration handle one argument (if there are any)
-    auto char_iter = fmt_str.begin();
-    while (char_iter != fmt_str.end())
+    auto curr_c = fmt_str.begin();
+    auto segment_start = curr_c; // non-formatted part
+    auto const end_c = fmt_str.end();
+
+    // each iteration handles one argument (if there are any)
+    while (true)
     {
-        auto segment_start = char_iter;
-        // find next occurence of '{', or end, and all occurrences of "}}"
-        while (char_iter != fmt_str.end() && *char_iter != '{')
+        if (curr_c == end_c)
+            break; // done
+
+        // } must belong to }} here
+        if (support_pythonic && *curr_c == '}')
         {
-            if (*char_iter == '}')
-            {
-                ss << cc::string_view(segment_start, char_iter);
-                ++char_iter;
-                CC_ASSERT(char_iter != fmt_str.end() && *char_iter == '}' && "Invalid format string: Unmatched }");
-                segment_start = char_iter;
-            }
-            ++char_iter;
+            ++curr_c;
+            CC_ASSERT_ERRMSG(curr_c != end_c && *curr_c == '}', fmt_str, {{curr_c, "expected '}'"}});
+
+            ss << cc::string_view(segment_start, curr_c);
+            ++curr_c;
+            segment_start = curr_c;
+            continue;
         }
 
-        // append current segment
-        if (char_iter != segment_start)
-            ss << cc::string_view(segment_start, char_iter);
-
-        // nothing to replace
-        if (char_iter == fmt_str.end())
-            return;
-
-        // char_iter now points to '{'
-        ++char_iter;
-        CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
-        if (*char_iter == '{') // escape second {
-            ss << cc::string_view(char_iter, char_iter + 1);
-        else if (*char_iter == '}')
+        // handle {} args
+        if (support_pythonic && *curr_c == '{')
         {
-            // case {}
-            CC_ASSERT(arg_id >= 0 && "Invalid format string: Cannot use {} after named or indexed argument");
-            CC_ASSERT(arg_id < int(args.size()) && "too many arguments for cc::format");
-            args[arg_id].do_format(ss, args[arg_id].data, {});
-            ++arg_id;
-        }
-        else
-        {
-            // optionally resolve index / name lookup
-            size_t argument_index = -1;
-            if (is_digit(*char_iter)) // number
+            auto const arg_start_c = curr_c;
+
+            // append segment in any case
+            if (segment_start != curr_c)
+                ss << cc::string_view(segment_start, curr_c);
+
+            ++curr_c;
+            CC_ASSERTF(curr_c != end_c, "{}", cc::make_error_message_for_substrings(fmt_str, {{curr_c, "expected argument or '{'"}}));
+
+            if (*curr_c == '{') // escaped {
             {
-                // todo: are leading zeros valid?
-                size_t index = *char_iter - '0';
-                ++char_iter;
-                CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
-                while (is_digit(*char_iter))
-                {
-                    index *= 10;
-                    index += *char_iter - '0';
-                    ++char_iter;
-                    CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
-                }
-                CC_ASSERT(index < args.size() && "Invalid format string: Argument index too large");
-                argument_index = index;
-                arg_id = -1; // invalidate
+                segment_start = curr_c; // next seg starts with '{'
+                ++curr_c;
+                continue;
             }
-            else if (*char_iter == '_' || is_lower(*char_iter) || is_upper(*char_iter)) // named
+
+            if (*curr_c == '}') // plain {}
             {
-                auto const name_start = char_iter;
-                ++char_iter;
-                CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
-                while (*char_iter == '_' || is_lower(*char_iter) || is_upper(*char_iter) || is_digit(*char_iter))
+                CC_ASSERTF(curr_arg_id >= 0, "{}",
+                           cc::make_error_message_for_substrings(fmt_str, {{{arg_start_c, curr_c + 1}, "cannot use {} after named or indexed argument"}}));
+                CC_ASSERTF(curr_arg_id < int(args.size()), "{}",
+                           cc::make_error_message_for_substrings(fmt_str, {{{arg_start_c, curr_c + 1}, "not enough arguments passed to cc::format"}}));
+                args[curr_arg_id].do_format(ss, args[curr_arg_id].data, {});
+                args[curr_arg_id].was_used = true;
+                ++curr_arg_id;
+            }
+            else // complex args
+            {
+                // optionally resolve index / name lookup
+                size_t argument_index = -1;
+                if (is_digit(*curr_c)) // number
                 {
-                    ++char_iter;
-                    CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
-                }
-                auto const name = cc::string_view(name_start, char_iter);
-                for (auto i = 0u; i < args.size(); ++i)
-                {
-                    if (!args[i].name.empty() && args[i].name == name)
+                    // TODO: are leading zeros valid?
+                    size_t index = *curr_c - '0';
+                    ++curr_c;
+                    CC_ASSERTF(curr_c != end_c, "{}", cc::make_error_message_for_substrings(fmt_str, {{{arg_start_c, curr_c}, "missing closing '}'"}}));
+                    while (is_digit(*curr_c))
                     {
-                        argument_index = i;
-                        break;
+                        index *= 10;
+                        index += *curr_c - '0';
+                        ++curr_c;
+                        CC_ASSERTF(curr_c != end_c, "{}", cc::make_error_message_for_substrings(fmt_str, {{{arg_start_c, curr_c}, "missing closing '}'"}}));
                     }
+                    CC_ASSERTF(index < args.size(), "{}",
+                               cc::make_error_message_for_substrings(
+                                   fmt_str, {{{arg_start_c, curr_c}, "argument index too large or not enough arguments passed to cc::format"}}));
+                    argument_index = index;
+                    curr_arg_id = -1; // invalidate
                 }
-                arg_id = -1; // invalidate
-                CC_ASSERT(argument_index < args.size() && "Invalid format string: Argument name not found");
-            }
-            else
-            {
-                argument_index = arg_id++;
-            }
-            CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
-            if (*char_iter == '}')
-            {
-                // we can only reach this if either a named or indexed argument is parsed
-                args[argument_index].do_format(ss, args[argument_index].data, {});
-            }
-            else
-            {
-                CC_ASSERT(*char_iter == ':' && "Invalid format string: Missing closing }");
-                ++char_iter;
-                CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
-                auto const args_start = char_iter;
-                while (*char_iter != '}')
+                else if (*curr_c == '_' || is_lower(*curr_c) || is_upper(*curr_c)) // named
                 {
-                    ++char_iter;
-                    CC_ASSERT(char_iter != fmt_str.end() && "Invalid format string: Missing closing }");
+                    auto const name_start = curr_c;
+                    ++curr_c;
+                    CC_ASSERTF(curr_c != end_c, "{}", cc::make_error_message_for_substrings(fmt_str, {{{arg_start_c, curr_c}, "missing closing '}'"}}));
+                    while (*curr_c == '_' || is_lower(*curr_c) || is_upper(*curr_c) || is_digit(*curr_c))
+                    {
+                        ++curr_c;
+                        CC_ASSERTF(curr_c != end_c, "{}", cc::make_error_message_for_substrings(fmt_str, {{{arg_start_c, curr_c}, "missing closing '}'"}}));
+                    }
+                    auto const name = cc::string_view(name_start, curr_c);
+                    for (auto i = 0u; i < args.size(); ++i)
+                    {
+                        if (!args[i].name.empty() && args[i].name == name)
+                        {
+                            argument_index = i;
+                            break;
+                        }
+                    }
+                    curr_arg_id = -1; // invalidate
+                    CC_ASSERTF(argument_index < args.size(),
+                               "{}", cc::make_error_message_for_substrings(fmt_str, {{name, "named argument not found in arguments passed to cc::format"}}));
                 }
-                // todo: handle arguments that themselves contain args
-                args[argument_index].do_format(ss, args[argument_index].data, cc::string_view(args_start, char_iter));
+                else
+                {
+                    argument_index = curr_arg_id++;
+                }
+                CC_ASSERTF(curr_c != end_c, "{}", cc::make_error_message_for_substrings(fmt_str, {{{arg_start_c, curr_c}, "missing closing '}'"}}));
+
+                if (*curr_c == '}') // no format string
+                {
+                    // we can only reach this if either a named or indexed argument is parsed
+                    args[argument_index].do_format(ss, args[argument_index].data, {});
+                    args[argument_index].was_used = true;
+                }
+                else
+                {
+                    CC_ASSERTF(*curr_c == ':', "{}",
+                               cc::make_error_message_for_substrings(fmt_str, {{{arg_start_c, curr_c}, "format specifier must start with ':'"}}));
+
+                    ++curr_c;
+                    CC_ASSERTF(curr_c != end_c, "{}", cc::make_error_message_for_substrings(fmt_str, {{{arg_start_c, curr_c}, "missing closing '}'"}}));
+
+                    auto const args_start = curr_c;
+                    while (*curr_c != '}')
+                    {
+                        ++curr_c;
+                        CC_ASSERTF(curr_c != end_c, "{}", cc::make_error_message_for_substrings(fmt_str, {{{arg_start_c, curr_c}, "missing closing '}'"}}));
+                    }
+
+                    // TODO: handle arguments that themselves contain args
+                    args[argument_index].do_format(ss, args[argument_index].data, cc::string_view(args_start, curr_c));
+                    args[argument_index].was_used = true;
+                }
             }
+
+            // start next segment
+            ++curr_c;
+            segment_start = curr_c;
+            continue;
         }
-        ++char_iter;
+
+        // no arg handling? just advance
+        ++curr_c;
     }
+
+    // add final segment
+    if (segment_start != end_c)
+        ss << cc::string_view(segment_start, end_c);
+
+    for (auto i = 0; i < int(args.size()); ++i)
+        CC_ASSERTF(args[i].was_used, "argument nr. {} as not used in format string '{}'", i, fmt_str);
+}
+}
+
+void cc::detail::default_formatter::vformat_to(cc::stream_ref<char> ss, cc::string_view fmt_str, cc::span<arg_info> args)
+{
+    detail::impl_vformat_to<true, true>(ss, fmt_str, args);
+}
+
+void cc::detail::printf_formatter::vformat_to(cc::stream_ref<char> ss, cc::string_view fmt_str, cc::span<arg_info> args)
+{
+    detail::impl_vformat_to<true, false>(ss, fmt_str, args);
+}
+
+void cc::detail::pythonic_formatter::vformat_to(cc::stream_ref<char> ss, cc::string_view fmt_str, cc::span<arg_info> args)
+{
+    detail::impl_vformat_to<false, true>(ss, fmt_str, args);
 }

--- a/src/clean-core/format.cc
+++ b/src/clean-core/format.cc
@@ -11,6 +11,7 @@ namespace cc::detail
 static void advance_printf_chars(cc::string_view fmt_str, char const*& curr, char const* end)
 {
     // taken from https://en.cppreference.com/w/cpp/io/c/fprintf
+    // with slight modification: alignemnt is supported via ><^
 
     // [optional] one or more flags that modify the behavior of the conversion
     while (curr != end
@@ -19,6 +20,9 @@ static void advance_printf_chars(cc::string_view fmt_str, char const*& curr, cha
                *curr == ' ' || //
                *curr == '-' || //
                *curr == '#' || //
+               *curr == '^' || //
+               *curr == '<' || //
+               *curr == '>' || //
                *curr == '0'))
         ++curr;
 

--- a/src/clean-core/format.cc
+++ b/src/clean-core/format.cc
@@ -175,7 +175,7 @@ static void impl_vformat_to(cc::stream_ref<char> ss, cc::string_view fmt_str, cc
         if (support_pythonic && *curr_c == '}')
         {
             ++curr_c;
-            CC_ASSERT_ERRMSG(curr_c != end_c && *curr_c == '}', fmt_str, {{curr_c, "expected '}'"}});
+            CC_ASSERT_ERRMSG(curr_c != end_c && *curr_c == '}', fmt_str, {{curr_c, "expected '}' (or missing earlier '{')"}});
 
             ss << cc::string_view(segment_start, curr_c);
             ++curr_c;

--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -174,6 +174,7 @@ struct default_do_format
         bool was_used = false;
     };
 
+    // TODO: maybe pull out the lambda into a template function to reduce symbol size a bit
     template <class T>
     static arg_info make_arg_info(T const& v)
     {

--- a/tests/format.cc
+++ b/tests/format.cc
@@ -1,0 +1,10 @@
+#include <nexus/test.hh>
+
+#include <clean-core/format.hh>
+
+TEST("cc::format basics")
+{
+    CHECK(cc::format("{}", 17) == "17");
+    CHECK(cc::format("{} + {} = {}", 1, 2, 3) == "1 + 2 = 3");
+    CHECK(cc::format("{} + {} = {", 1, 2, 3) == "1 + 2 = 3");
+}

--- a/tests/format.cc
+++ b/tests/format.cc
@@ -33,3 +33,11 @@ TEST("cc::format opinionated")
     CHECK(cc::formatf("{} %s", "x") == "{} x");
     CHECK(cc::formatp("{} %s", "x") == "x %s");
 }
+
+TEST("cc::format string format")
+{
+    CHECK(cc::format("%s", "hi") == "hi");
+    CHECK(cc::format("%5s", "hi") == "   hi");
+    CHECK(cc::format("%<5s", "hi") == "hi   ");
+    CHECK(cc::format("%^4s", "hi") == " hi ");
+}

--- a/tests/format.cc
+++ b/tests/format.cc
@@ -6,5 +6,24 @@ TEST("cc::format basics")
 {
     CHECK(cc::format("{}", 17) == "17");
     CHECK(cc::format("{} + {} = {}", 1, 2, 3) == "1 + 2 = 3");
-    CHECK(cc::format("{} + {} = {", 1, 2, 3) == "1 + 2 = 3");
+
+    // reordering
+    CHECK(cc::format("{2} - {0} = {1}", 1, 2, 3) == "3 - 1 = 2");
+    CHECK(cc::format("{1} {0}!", "World", "Hello") == "Hello World!");
+
+    // escaping
+    CHECK(cc::format("this {{}} is used for args like {}", "this") == "this {} is used for args like this");
+
+    // format strings
+    CHECK(cc::format("{:4}", 12) == "  12");
+    CHECK(cc::format("{:.2f}", 1.2345) == "1.23");
+
+    // decorators?
+    // cc::format("{}", cc::fmt_join(my_vec, ", ")))
+}
+
+TEST("cc::format opinionated")
+{
+    CHECK(cc::formatf("{}") == "{}");
+    CHECK(cc::formatp("%s") == "%s");
 }

--- a/tests/format.cc
+++ b/tests/format.cc
@@ -6,6 +6,9 @@ TEST("cc::format basics")
 {
     CHECK(cc::format("{}", 17) == "17");
     CHECK(cc::format("{} + {} = {}", 1, 2, 3) == "1 + 2 = 3");
+    CHECK(cc::format("%s + %d = %x", 1, 2, 3) == "1 + 2 = 3");
+    CHECK(cc::format("{}{}{}", 1, 2, 3) == "123");
+    CHECK(cc::format("%s%d%x", 1, 2, 3) == "123");
 
     // reordering
     CHECK(cc::format("{2} - {0} = {1}", 1, 2, 3) == "3 - 1 = 2");
@@ -13,10 +16,13 @@ TEST("cc::format basics")
 
     // escaping
     CHECK(cc::format("this {{}} is used for args like {}", "this") == "this {} is used for args like this");
+    CHECK(cc::format("look ma, I can write %% and {{ and }}") == "look ma, I can write % and { and }");
 
     // format strings
     CHECK(cc::format("{:4}", 12) == "  12");
+    CHECK(cc::format("%4d", 12) == "  12");
     CHECK(cc::format("{:.2f}", 1.2345) == "1.23");
+    CHECK(cc::format("%.2f", 1.2345) == "1.23");
 
     // decorators?
     // cc::format("{}", cc::fmt_join(my_vec, ", ")))
@@ -24,6 +30,6 @@ TEST("cc::format basics")
 
 TEST("cc::format opinionated")
 {
-    CHECK(cc::formatf("{}") == "{}");
-    CHECK(cc::formatp("%s") == "%s");
+    CHECK(cc::formatf("{} %s", "x") == "{} x");
+    CHECK(cc::formatp("{} %s", "x") == "x %s");
 }


### PR DESCRIPTION
* `cc::format` now supports a generic `%s` (for all types) and other printf format specifier
* `cc::formatf` and `cc::formatp` are versions where explicitly only one of the syntaxes is supported (this is also particularly useful if you would need to escape a lot of {} or %)
* added a utility function `cc::make_error_message_for_substrings` that can be used to conveniently create awesome ASCII art error messages for errors in any kind of string