### PR TITLE
Back on track

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,9 +46,15 @@ if(NOT CMAKE_BUILD_TYPE)
         "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
-target_compile_definitions(clean-core PUBLIC $<$<CONFIG:DEBUG>:CC_DEBUG>)
-target_compile_definitions(clean-core PUBLIC $<$<CONFIG:RELEASE>:CC_RELEASE>)
-target_compile_definitions(clean-core PUBLIC $<$<CONFIG:RELWITHDEBINFO>:CC_RELWITHDEBINFO>)
+target_link_libraries(clean-core PUBLIC
+    $<$<PLATFORM_ID:Linux>:-pthread>
+)
+
+target_compile_definitions(clean-core PUBLIC
+    $<$<CONFIG:DEBUG>:CC_DEBUG>
+    $<$<CONFIG:RELEASE>:CC_RELEASE>
+    $<$<CONFIG:RELWITHDEBINFO>:CC_RELWITHDEBINFO>
+)
 
 if (CC_ENABLE_ASSERTIONS)
     target_compile_definitions(clean-core PUBLIC $<$<CONFIG:DEBUG>:CC_ENABLE_ASSERTIONS>)

--- a/clean_core.natvis
+++ b/clean_core.natvis
@@ -25,7 +25,7 @@
   </Type>
 
   <Type Name="cc::alloc_vector&lt;*&gt;">
-    <DisplayString>{{ alloc_vector size={_size)} }}</DisplayString>
+    <DisplayString>{{ alloc_vector size={_size} }}</DisplayString>
     <Expand>
       <Item Name="[size]">_size</Item>
       <Item Name="[capacity]">_capacity</Item>

--- a/src/clean-core/allocator.cc
+++ b/src/clean-core/allocator.cc
@@ -41,16 +41,12 @@ std::byte* cc::allocator::realloc(void* ptr, size_t old_size, size_t new_size, s
     return res;
 }
 
-std::byte* cc::allocator::alloc_request(size_t min_size, size_t request_size, size_t& out_received_size, size_t align)
+std::byte* cc::allocator::try_alloc(size_t size, size_t alignment)
 {
-    CC_UNUSED(request_size);
-    out_received_size = min_size;
-    return this->alloc(min_size, align);
+    return this->alloc(size, alignment);
 }
 
-std::byte* cc::allocator::realloc_request(void* ptr, size_t old_size, size_t new_min_size, size_t request_size, size_t& out_received_size, size_t align)
+std::byte* cc::allocator::try_realloc(void* ptr, size_t old_size, size_t new_size, size_t alignment)
 {
-    CC_UNUSED(request_size);
-    out_received_size = new_min_size;
-    return this->realloc(ptr, old_size, new_min_size, align);
+    return this->realloc(ptr, old_size, new_size, alignment);
 }

--- a/src/clean-core/allocator.cc
+++ b/src/clean-core/allocator.cc
@@ -23,7 +23,7 @@ char* cc::allocator::alloc_string_copy(cc::string_view source)
     return res;
 }
 
-std::byte* cc::allocator::realloc(void* ptr, size_t old_size, size_t new_size, size_t align)
+std::byte* cc::allocator::realloc(void* ptr, size_t new_size, size_t align)
 {
     std::byte* res = nullptr;
 
@@ -33,6 +33,10 @@ std::byte* cc::allocator::realloc(void* ptr, size_t old_size, size_t new_size, s
 
         if (ptr != nullptr)
         {
+            size_t old_size = 0;
+            bool got_old_size = this->get_allocation_size(ptr, old_size);
+            CC_RUNTIME_ASSERT(got_old_size && "Allocator with default realloc failed to provide old allocation size");
+
             std::memcpy(res, ptr, cc::min(old_size, new_size));
         }
     }
@@ -41,12 +45,6 @@ std::byte* cc::allocator::realloc(void* ptr, size_t old_size, size_t new_size, s
     return res;
 }
 
-std::byte* cc::allocator::try_alloc(size_t size, size_t alignment)
-{
-    return this->alloc(size, alignment);
-}
+std::byte* cc::allocator::try_alloc(size_t size, size_t alignment) { return this->alloc(size, alignment); }
 
-std::byte* cc::allocator::try_realloc(void* ptr, size_t old_size, size_t new_size, size_t alignment)
-{
-    return this->realloc(ptr, old_size, new_size, alignment);
-}
+std::byte* cc::allocator::try_realloc(void* ptr, size_t new_size, size_t alignment) { return this->realloc(ptr, new_size, alignment); }

--- a/src/clean-core/allocator.hh
+++ b/src/clean-core/allocator.hh
@@ -28,18 +28,18 @@ public:
     // specific interfaces which can be overriden by allocators
 
     // reallocate a buffer, behaves like std::realloc
-    virtual std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t));
+    virtual std::byte* realloc(void* ptr, size_t new_size, size_t align = alignof(std::max_align_t));
 
     // can return nullptr if the request can't be satisfied
     [[nodiscard]] virtual std::byte* try_alloc(size_t size, size_t alignment = alignof(std::max_align_t));
 
     // can return nullptr if the request can't be satisfied
     // the original buffer will remain valid in that case
-    virtual std::byte* try_realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t));
+    virtual std::byte* try_realloc(void* ptr, size_t new_size, size_t align = alignof(std::max_align_t));
 
     // reads the size of the given allocation
     // only some allocators can do this, returns true if available
-    virtual bool get_allocation_size(void* ptr, size_t& out_size) { return false; }
+    virtual bool get_allocation_size(void const* ptr, size_t& out_size) { return false; }
 
     // some allocators can internally validate the heap for corruptions
     // returns true if validation is available (asserts internally)

--- a/src/clean-core/allocator.hh
+++ b/src/clean-core/allocator.hh
@@ -12,11 +12,45 @@ namespace cc
 {
 struct allocator
 {
-    /// allocate a buffer with specified size and alignment
+public:
+    //
+    // pure virtual
+
+    // allocate a buffer with specified size and alignment
     [[nodiscard]] virtual std::byte* alloc(size_t size, size_t align = alignof(std::max_align_t)) = 0;
 
-    /// free a pointer previously received from alloc
+    // free a previously allocated buffer
     virtual void free(void* ptr) = 0;
+
+public:
+    //
+    // optional virtual
+    // specific interfaces which can be overriden by allocators
+
+    // reallocate a buffer, behaves like std::realloc
+    virtual std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t));
+
+    // can return nullptr if the request can't be satisfied
+    [[nodiscard]] virtual std::byte* try_alloc(size_t size, size_t alignment = alignof(std::max_align_t));
+
+    // can return nullptr if the request can't be satisfied
+    // the original buffer will remain valid in that case
+    virtual std::byte* try_realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t));
+
+    // reads the size of the given allocation
+    // only some allocators can do this, returns true if available
+    virtual bool get_allocation_size(void* ptr, size_t& out_size) { return false; }
+
+    // some allocators can internally validate the heap for corruptions
+    // returns true if validation is available (asserts internally)
+    virtual bool validate_heap() { return false; }
+
+    // returns a descriptive name of this allocator
+    virtual char const* get_name() const { return "Unnamed Allocator"; }
+
+public:
+    //
+    // non-virtual utility
 
     /// allocate and construct an object
     template <class T, class... Args>
@@ -47,19 +81,6 @@ struct allocator
 
     template <class T>
     T* alloc_data_copy(cc::span<T const> data);
-
-    // below:
-    // specific interfaces which can be overriden by allocators to be more efficient, with fallback otherwise
-
-    /// reallocate a buffer, behaves like std::realloc
-    virtual std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t));
-
-    /// allocate a buffer with specified minimum size, will span up to request_size if possible
-    [[nodiscard]] virtual std::byte* alloc_request(size_t min_size, size_t request_size, size_t& out_received_size, size_t align = alignof(std::max_align_t));
-
-    /// reallocate a buffer with specified minimum size, will span up to request_size if possible
-    [[nodiscard]] virtual std::byte* realloc_request(
-        void* ptr, size_t old_size, size_t new_min_size, size_t request_size, size_t& out_received_size, size_t align = alignof(std::max_align_t));
 
     // delete copy, default move
     allocator() = default;

--- a/src/clean-core/allocators/linear_allocator.hh
+++ b/src/clean-core/allocators/linear_allocator.hh
@@ -6,17 +6,23 @@ namespace cc
 {
 /// trivial linear allocator operating in a given buffer
 /// cannot free individual allocations, only reset entirely
+/// Will only take as much space as strictly necessary (no allocation headers)
+///
+/// RESTRICTION: Must only realloc the most recent allocation
 struct linear_allocator final : allocator
 {
     std::byte* alloc(size_t size, size_t align = alignof(std::max_align_t)) override
     {
         CC_ASSERT(_buffer_begin != nullptr && "linear_allocator uninitialized");
 
+        align = cc::max<size_t>(align, 1);
+
         auto* const padded_res = cc::align_up(_head, align);
         CC_ASSERT(padded_res + size <= _buffer_end && "linear_allocator overcommitted");
-        _head = padded_res + size;
 
+        _head = padded_res + size;
         _latest_allocation = padded_res;
+
         return padded_res;
     }
 
@@ -26,20 +32,37 @@ struct linear_allocator final : allocator
         (void)ptr;
     }
 
-    std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t)) override
+    bool get_allocation_size(void const* ptr, size_t& out_size) override
     {
         if (!ptr || ptr != _latest_allocation)
+            return false;
+
+        out_size = _head - _latest_allocation;
+        return true;
+    }
+
+    std::byte* realloc(void* ptr, size_t new_size, size_t align = alignof(std::max_align_t)) override
+    {
+        if (ptr)
         {
-            return new_size > 0 ? this->alloc(new_size, align) : nullptr;
+            // real realloc
+
+            // for a "generally usable" linear allocator without any restriction, use atomic_linear_allocator
+            // linear_allocator guarantees to only use as much space as strictly necessary and thus can't store headers
+            CC_ASSERT(ptr == _latest_allocation && "linear_allocator can only realloc the most recent allocation");
+
+            std::byte* const ptr_byte = static_cast<std::byte*>(ptr);
+            CC_ASSERT(ptr_byte + new_size <= _buffer_end && "linear_allocator overcommitted");
+
+            _head = ptr_byte + new_size;
+            return ptr_byte;
         }
 
-        std::byte* const ptr_byte = static_cast<std::byte*>(ptr);
-        CC_ASSERT(old_size == _head - ptr_byte && "old_size incorrect");
-        CC_ASSERT(ptr_byte + new_size <= _buffer_end && "linear_allocator overcommitted");
-
-        _head = ptr_byte + new_size;
-        return ptr_byte;
+        // fall back to default behavior
+        return cc::allocator::realloc(ptr, new_size, align);
     }
+
+    char const* get_name() const override { return "Linear Allocator"; }
 
     void reset()
     {

--- a/src/clean-core/allocators/stack_allocator.cc
+++ b/src/clean-core/allocators/stack_allocator.cc
@@ -40,12 +40,12 @@ void cc::stack_allocator::free(void* ptr)
     _head = byte_ptr - alloc_header->padding;
 }
 
-std::byte* cc::stack_allocator::realloc(void* ptr, size_t old_size, size_t new_size, size_t align)
+std::byte* cc::stack_allocator::realloc(void* ptr, size_t new_size, size_t align)
 {
     if (new_size == 0)
     {
         // free case
-        free(ptr);
+        this->free(ptr);
         return nullptr;
     }
     else if (ptr == nullptr)
@@ -54,7 +54,6 @@ std::byte* cc::stack_allocator::realloc(void* ptr, size_t old_size, size_t new_s
         return this->alloc(new_size, align);
     }
 
-    (void)old_size;
     (void)align;
     // no need to memcpy, the memory remains the same
     std::byte* const byte_ptr = static_cast<std::byte*>(ptr);
@@ -62,7 +61,7 @@ std::byte* cc::stack_allocator::realloc(void* ptr, size_t old_size, size_t new_s
 
     CC_ASSERT(alloc_header->alloc_id == _last_alloc_id && "realloc ptr was not the most recent allocation");
     CC_ASSERT(byte_ptr + new_size <= _buffer_end && "stack_allocator overcommitted");
-    CC_ASSERT(old_size == _head - byte_ptr && "incorrect old size");
+    // CC_ASSERT(old_size == _head - byte_ptr && "incorrect old size");
 
     _head = byte_ptr + new_size;
     return byte_ptr;

--- a/src/clean-core/allocators/stack_allocator.hh
+++ b/src/clean-core/allocators/stack_allocator.hh
@@ -6,6 +6,8 @@ namespace cc
 {
 /// stack allocator operating in a given buffer
 /// like a linear allocator, but can also free the most recent allocation
+///
+/// RESTRICTION: Must only free or realloc the most recent allocation
 struct stack_allocator final : allocator
 {
     std::byte* alloc(size_t size, size_t align = alignof(std::max_align_t)) override;
@@ -14,7 +16,9 @@ struct stack_allocator final : allocator
     void free(void* ptr) override;
 
     /// NOTE: ptr must be the most recent allocation received
-    std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t)) override;
+    std::byte* realloc(void* ptr, size_t new_size, size_t align = alignof(std::max_align_t)) override;
+
+    char const* get_name() const override { return "Stack Allocator"; }
 
     void reset()
     {

--- a/src/clean-core/allocators/synced_tlsf_allocator.hh
+++ b/src/clean-core/allocators/synced_tlsf_allocator.hh
@@ -3,8 +3,8 @@
 #include <clean-core/allocator.hh>
 
 #include <clean-core/allocators/tlsf_allocator.hh>
-#include <clean-core/spin_lock.hh>
 #include <clean-core/lock_guard.hh>
+#include <clean-core/spin_lock.hh>
 
 namespace cc
 {
@@ -14,7 +14,7 @@ struct synced_tlsf_allocator final : allocator
 {
     synced_tlsf_allocator() = default;
     explicit synced_tlsf_allocator(cc::span<std::byte> buffer) : _backing(buffer) {}
-    ~synced_tlsf_allocator() { _backing.destroy(); }
+    ~synced_tlsf_allocator() { destroy(); }
 
 
     std::byte* alloc(size_t size, size_t align = alignof(std::max_align_t)) override
@@ -29,14 +29,32 @@ struct synced_tlsf_allocator final : allocator
         _backing.free(ptr);
     }
 
-    std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t)) override
+    std::byte* realloc(void* ptr, size_t new_size, size_t align = alignof(std::max_align_t)) override
     {
         auto lg = cc::lock_guard(_lock);
-        return _backing.realloc(ptr, old_size, new_size, align);
+        return _backing.realloc(ptr, new_size, align);
     }
 
+    bool get_allocation_size(void const* ptr, size_t& out_size) override
+    {
+        auto lg = cc::lock_guard(_lock);
+        return _backing.get_allocation_size(ptr, out_size);
+    }
+
+    bool validate_heap() override
+    {
+        auto lg = cc::lock_guard(_lock);
+        return _backing.validate_heap();
+    }
+
+    char const* get_name() const override { return "Synced TLSF Allocator"; }
+
     void initialize(cc::span<std::byte> buffer) { _backing.initialize(buffer); }
-    void destroy() { _backing.destroy(); }
+    void destroy()
+    {
+        auto lg = cc::lock_guard(_lock);
+        _backing.destroy();
+    }
 
 private:
     LockT _lock;

--- a/src/clean-core/allocators/synced_virtual_linear_allocator.hh
+++ b/src/clean-core/allocators/synced_virtual_linear_allocator.hh
@@ -32,11 +32,13 @@ struct synced_virtual_linear_allocator final : allocator
 
     void free(void*) override {} // nothing
 
-    std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t)) override
+    std::byte* realloc(void* ptr, size_t new_size, size_t align = alignof(std::max_align_t)) override
     {
         auto lg = cc::lock_guard(_mutex);
-        return _backing.realloc(ptr, old_size, new_size, align);
+        return _backing.realloc(ptr, new_size, align);
     }
+
+	char const* get_name() const override { return "Synced Virtual Linear Allocator"; }
 
     size_t reset()
     {

--- a/src/clean-core/allocators/system_allocator.cc
+++ b/src/clean-core/allocators/system_allocator.cc
@@ -1,3 +1,5 @@
+#include "system_allocator.hh"
+
 #include <clean-core/allocator.hh>
 
 #include <clean-core/macros.hh>
@@ -12,139 +14,92 @@
 #include <cstdlib>
 #endif
 
-namespace cc
+std::byte* cc::system_malloc(size_t size, size_t alignment)
 {
-namespace
-{
-// system provided allocator (malloc / free)
-struct system_allocator_t final : cc::allocator
-{
-    std::byte* try_alloc(size_t size, size_t alignment) override
-    {
-        alignment = cc::max<size_t>(alignment, size >= 16 ? 16 : 8);
+    alignment = cc::max<size_t>(alignment, size >= 16 ? 16 : 8);
 
 #if CC_USE_ALIGNED_MALLOC
-        void* result = ::_aligned_malloc(size, alignment);
+    void* result = ::_aligned_malloc(size, alignment);
 #else
-        void* ptr = std::malloc(size + alignment + sizeof(void*) + sizeof(size_t));
-        void* result = nullptr;
-        if (ptr)
-        {
-            result = cc::align_up((uint8_t*)ptr + sizeof(void*) + sizeof(size_t), alignment);
-            *((void**)((uint8_t*)result - sizeof(void*))) = ptr;
-            *((size_t*)((uint8_t*)result - sizeof(void*) - sizeof(size_t))) = size;
-        }
+    void* ptr = std::malloc(size + alignment + sizeof(void*) + sizeof(size_t));
+    void* result = nullptr;
+    if (ptr)
+    {
+        result = cc::align_up((uint8_t*)ptr + sizeof(void*) + sizeof(size_t), alignment);
+        *((void**)((uint8_t*)result - sizeof(void*))) = ptr;
+        *((size_t*)((uint8_t*)result - sizeof(void*) - sizeof(size_t))) = size;
+    }
 #endif
 
-        return static_cast<std::byte*>(result);
-    }
+    return static_cast<std::byte*>(result);
+}
 
-    std::byte* alloc(size_t size, size_t alignment) override
-    {
-        std::byte* const result = this->try_alloc(size, alignment);
-
-        CC_RUNTIME_ASSERT((result != nullptr || size == 0) && "Out of system memory - allocation failed");
-
-        return result;
-    }
-
-    std::byte* try_realloc(void* ptr, size_t new_size, size_t align) override
-    {
-        align = cc::max<size_t>(align, new_size >= 16 ? 16 : 8);
+std::byte* cc::system_realloc(void* ptr, size_t new_size, size_t align)
+{
+    align = cc::max<size_t>(align, new_size >= 16 ? 16 : 8);
 
 #if CC_USE_ALIGNED_MALLOC
-        void* result;
+    void* result;
 
-        if (ptr && new_size)
-        {
-            result = ::_aligned_realloc(ptr, new_size, align);
-        }
-        else if (!ptr)
-        {
-            result = ::_aligned_malloc(new_size, align);
-        }
-        else
-        {
-            ::_aligned_free(ptr);
-            result = nullptr;
-        }
+    if (ptr && new_size)
+    {
+        result = ::_aligned_realloc(ptr, new_size, align);
+    }
+    else if (!ptr)
+    {
+        result = ::_aligned_malloc(new_size, align);
+    }
+    else
+    {
+        ::_aligned_free(ptr);
+        result = nullptr;
+    }
 
-        return static_cast<std::byte*>(result);
+    return static_cast<std::byte*>(result);
 
 #else // !CC_USE_ALIGNED_MALLOC
       // default realloc implementation
-        return cc::allocator::realloc(ptr, new_size, align);
-#endif
-    }
-
-    std::byte* realloc(void* ptr, size_t new_size, size_t align) override
+    std::byte* res = nullptr;
+    if (new_size > 0)
     {
-        std::byte* result = this->try_realloc(ptr, new_size, align);
+        res = cc::system_malloc(new_size, align);
 
-        CC_RUNTIME_ASSERT((result != nullptr || new_size == 0) && "Out of system memory - allocation failed");
-
-        return result;
-    }
-
-    void free(void* ptr) override
-    {
-#if CC_USE_ALIGNED_MALLOC
-        ::_aligned_free(ptr);
-#else
-        if (ptr)
+        if (ptr != nullptr)
         {
-            std::free(*((void**)((uint8_t*)ptr - sizeof(void*))));
+            size_t const old_size = cc::system_msize(ptr);
+            std::memcpy(res, ptr, cc::min(old_size, new_size));
         }
-#endif
     }
 
-    bool get_allocation_size(void const* ptr, size_t& out_size) override
-    {
-        if (!ptr)
-        {
-            return false;
-        }
-
-#if CC_USE_ALIGNED_MALLOC
-        out_size = ::_aligned_msize(const_cast<void*>(ptr), 16, 0);
-        return true;
-#else
-        out_size = *((size_t*)((uint8_t*)ptr - sizeof(void*) - sizeof(size_t)));
-        return true;
+    cc::system_free(ptr);
+    return res;
 #endif
-    }
-
-    bool validate_heap() override
-    {
-#ifdef CC_OS_WINDOWS
-
-        int32_t const res = _heapchk();
-
-        CC_RUNTIME_ASSERT(res != _HEAPBADBEGIN && "Heap check: Initial header information is bad or can't be found.");
-        CC_RUNTIME_ASSERT(res != _HEAPBADNODE && "Heap check: Bad node has been found or heap is damaged.");
-        CC_RUNTIME_ASSERT(res != _HEAPBADPTR && "Heap check: Pointer into heap isn't valid.");
-        CC_RUNTIME_ASSERT(res != _HEAPEMPTY && "Heap check: Heap hasn't been initialized.");
-
-        CC_RUNTIME_ASSERT(res == _HEAPOK && "Heap check: Unknown issue");
-
-        return true;
-#else
-        return false;
-#endif
-    }
-
-    char const* get_name() const override
-    {
-#if CC_USE_ALIGNED_MALLOC
-        return "C runtime allocator (_aligned_malloc)";
-#else
-        return "C runtime allocator (malloc)";
-#endif
-    }
-
-    constexpr system_allocator_t() = default;
-};
 }
+
+size_t cc::system_msize(void const* ptr)
+{
+    if (!ptr)
+    {
+        return 0;
+    }
+
+#if CC_USE_ALIGNED_MALLOC
+    return ::_aligned_msize(const_cast<void*>(ptr), 16, 0);
+#else
+    return *((size_t*)((uint8_t*)ptr - sizeof(void*) - sizeof(size_t)));
+#endif
+}
+
+void cc::system_free(void* ptr)
+{
+#if CC_USE_ALIGNED_MALLOC
+    ::_aligned_free(ptr);
+#else
+    if (ptr)
+    {
+        std::free(*((void**)((uint8_t*)ptr - sizeof(void*))));
+    }
+#endif
 }
 
 /*
@@ -167,3 +122,31 @@ static union sys_alloc_union_t
 } sys_alloc_instance;
 
 cc::allocator* const cc::system_allocator = &sys_alloc_instance.alloc;
+
+bool cc::system_allocator_t::validate_heap()
+{
+#ifdef CC_OS_WINDOWS
+
+    int32_t const res = _heapchk();
+
+    CC_RUNTIME_ASSERT(res != _HEAPBADBEGIN && "Heap check: Initial header information is bad or can't be found.");
+    CC_RUNTIME_ASSERT(res != _HEAPBADNODE && "Heap check: Bad node has been found or heap is damaged.");
+    CC_RUNTIME_ASSERT(res != _HEAPBADPTR && "Heap check: Pointer into heap isn't valid.");
+    CC_RUNTIME_ASSERT(res != _HEAPEMPTY && "Heap check: Heap hasn't been initialized.");
+
+    CC_RUNTIME_ASSERT(res == _HEAPOK && "Heap check: Unknown issue");
+
+    return true;
+#else
+    return false;
+#endif
+}
+
+char const* cc::system_allocator_t::get_name() const
+{
+#if CC_USE_ALIGNED_MALLOC
+    return "C runtime allocator (_aligned_malloc)";
+#else
+    return "C runtime allocator (malloc)";
+#endif
+}

--- a/src/clean-core/allocators/system_allocator.hh
+++ b/src/clean-core/allocators/system_allocator.hh
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <clean-core/allocator.hh>
+
+namespace cc
+{
+//
+// underlying logic of cc::system_allocator_t as free functions
+// required for some pre-main scenarios (e.g. non-alloc vector)
+
+std::byte* system_malloc(size_t size, size_t alignment);
+
+std::byte* system_realloc(void* ptr, size_t new_size, size_t align);
+
+size_t system_msize(void const* ptr);
+
+void system_free(void* ptr);
+
+// system provided allocator (malloc / free)
+struct system_allocator_t final : cc::allocator
+{
+    std::byte* try_alloc(size_t size, size_t alignment) override { return cc::system_malloc(size, alignment); }
+
+    std::byte* alloc(size_t size, size_t alignment) override
+    {
+        std::byte* const result = this->try_alloc(size, alignment);
+        CC_RUNTIME_ASSERT((result != nullptr || size == 0) && "Out of system memory - allocation failed");
+        return result;
+    }
+
+    std::byte* try_realloc(void* ptr, size_t new_size, size_t align) override { return cc::system_realloc(ptr, new_size, align); }
+
+    std::byte* realloc(void* ptr, size_t new_size, size_t align) override
+    {
+        std::byte* result = this->try_realloc(ptr, new_size, align);
+        CC_RUNTIME_ASSERT((result != nullptr || new_size == 0) && "Out of system memory - allocation failed");
+        return result;
+    }
+
+    void free(void* ptr) override { cc::system_free(ptr); }
+
+    bool get_allocation_size(void const* ptr, size_t& out_size) override
+    {
+        out_size = cc::system_msize(ptr);
+        return true;
+    }
+
+    bool validate_heap() override;
+
+    char const* get_name() const override;
+
+    constexpr system_allocator_t() = default;
+};
+}

--- a/src/clean-core/allocators/tlsf_allocator.hh
+++ b/src/clean-core/allocators/tlsf_allocator.hh
@@ -19,14 +19,17 @@ struct tlsf_allocator final : allocator
     // provide an additional memory pool to the TLSF (can be done multiple times)
     void add_pool(cc::span<std::byte> buffer);
 
-    // returns false if internal consistency checks fail
-    bool check_consistency();
-
     std::byte* alloc(size_t size, size_t align = alignof(std::max_align_t)) override;
 
     void free(void* ptr) override;
 
-    std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t)) override;
+    std::byte* realloc(void* ptr, size_t new_size, size_t align = alignof(std::max_align_t)) override;
+
+    bool get_allocation_size(void const* ptr, size_t& out_size) override;
+
+    bool validate_heap() override;
+
+    char const* get_name() const override { return "TLSF Allocator"; }
 
     tlsf_allocator(tlsf_allocator&& rhs) noexcept : _tlsf(rhs._tlsf) { rhs._tlsf = nullptr; }
     tlsf_allocator& operator==(tlsf_allocator&& rhs) noexcept

--- a/src/clean-core/allocators/virtual_linear_allocator.hh
+++ b/src/clean-core/allocators/virtual_linear_allocator.hh
@@ -24,7 +24,11 @@ struct virtual_linear_allocator final : allocator
 
     void free(void* ptr) override { (void)ptr; }
 
-    std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t)) override;
+    bool get_allocation_size(void const* ptr, size_t& out_size) override;
+
+    char const* get_name() const override { return "Virtual Linear Allocator"; }
+
+    std::byte* realloc(void* ptr, size_t new_size, size_t align = alignof(std::max_align_t)) override;
 
     // free all current allocations
     // does not decommit any memory!

--- a/src/clean-core/allocators/virtual_stack_allocator.cc
+++ b/src/clean-core/allocators/virtual_stack_allocator.cc
@@ -64,12 +64,12 @@ void cc::virtual_stack_allocator::free(void* ptr)
     _physical_current = byte_ptr - alloc_header->padding;
 }
 
-std::byte* cc::virtual_stack_allocator::realloc(void* ptr, size_t old_size, size_t new_size, size_t align)
+std::byte* cc::virtual_stack_allocator::realloc(void* ptr, size_t new_size, size_t align)
 {
     if (new_size == 0)
     {
         // free case
-        free(ptr);
+        this->free(ptr);
         return nullptr;
     }
     else if (ptr == nullptr)
@@ -83,7 +83,8 @@ std::byte* cc::virtual_stack_allocator::realloc(void* ptr, size_t old_size, size
     stack_alloc_header const* const alloc_header = (stack_alloc_header*)(byte_ptr - sizeof(stack_alloc_header));
 
     CC_ASSERT(alloc_header->alloc_id == _last_alloc_id && "realloc ptr was not the most recent allocation");
-    CC_ASSERT(old_size == _physical_current - byte_ptr && "incorrect old size");
+    size_t const old_size = _physical_current - byte_ptr;
+    // CC_ASSERT(old_size_arg == _physical_current - byte_ptr && "incorrect old size");
 
     if (new_size > old_size)
     {

--- a/src/clean-core/allocators/virtual_stack_allocator.hh
+++ b/src/clean-core/allocators/virtual_stack_allocator.hh
@@ -7,6 +7,8 @@ namespace cc
 /// stack allocator operating in virtual memory
 /// reserves pages on init, commits pages on demand
 /// only frees pages if explicitly called
+///
+/// RESTRICTION: Must only free or realloc the most recent allocation
 struct virtual_stack_allocator final : allocator
 {
     virtual_stack_allocator() = default;
@@ -26,7 +28,9 @@ struct virtual_stack_allocator final : allocator
     void free(void* ptr) override;
 
     /// NOTE: ptr must be the most recent allocation received
-    std::byte* realloc(void* ptr, size_t old_size, size_t new_size, size_t align = alignof(std::max_align_t)) override;
+    std::byte* realloc(void* ptr, size_t new_size, size_t align = alignof(std::max_align_t)) override;
+
+    char const* get_name() const override { return "Virtual Stack Allocator"; }
 
     // free all current allocations
     // does not decommit any memory!

--- a/src/clean-core/assert.hh
+++ b/src/clean-core/assert.hh
@@ -104,7 +104,7 @@ CC_COLD_FUNC CC_DONT_INLINE void assertion_failed(assertion_info const& info);
 CC_COLD_FUNC CC_DONT_INLINE bool is_debugger_connected();
 
 /// calls std::abort(), avoids includes
-CC_COLD_FUNC CC_DONT_INLINE void perform_abort();
+[[noreturn]] CC_COLD_FUNC CC_DONT_INLINE void perform_abort();
 }
 
 namespace cc

--- a/src/clean-core/atomic_linked_pool.hh
+++ b/src/clean-core/atomic_linked_pool.hh
@@ -8,7 +8,6 @@
 #include <clean-core/alloc_vector.hh>
 #include <clean-core/allocator.hh>
 #include <clean-core/bit_cast.hh>
-#include <clean-core/bits.hh>
 #include <clean-core/new.hh>
 
 namespace cc

--- a/src/clean-core/bits.hh
+++ b/src/clean-core/bits.hh
@@ -7,7 +7,10 @@
 #ifdef CC_COMPILER_MSVC
 #include <intrin.h>
 #else
+#ifndef __cpuid
+// NOTE: this file does not (always) have include guards
 #include <cpuid.h>
+#endif
 #include <x86intrin.h>
 #endif
 

--- a/src/clean-core/detail/lib/StackWalker.cc
+++ b/src/clean-core/detail/lib/StackWalker.cc
@@ -89,7 +89,7 @@
 #include <stdlib.h>
 #include <tchar.h>
 
-#include <Windows.h>
+#include <clean-core/native/win32_sanitized.hh>
 
 #pragma comment(lib, "version.lib") // for "VerQueryValue"
 #pragma warning(disable : 4826)

--- a/src/clean-core/detail/lib/StackWalker.cc
+++ b/src/clean-core/detail/lib/StackWalker.cc
@@ -437,7 +437,7 @@ public:
         // new elements: 17-Dec-2003
         BOOL SourceIndexed; // pdb supports source server
         BOOL Publics;       // contains public symbols
-    };
+    } IMAGEHLP_MODULE64_V3;
 
     typedef struct IMAGEHLP_MODULE64_V2
     {
@@ -451,7 +451,7 @@ public:
         CHAR ModuleName[32];       // module name
         CHAR ImageName[256];       // image name
         CHAR LoadedImageName[256]; // symbol file name
-    };
+    } IMAGEHLP_MODULE64_V2;
 #pragma pack(pop)
 
     // SymCleanup()

--- a/src/clean-core/detail/srange.hh
+++ b/src/clean-core/detail/srange.hh
@@ -62,6 +62,21 @@ struct irange
     CC_FORCE_INLINE constexpr iiterator<T> begin() const { return {_begin}; }
     CC_FORCE_INLINE constexpr iiterator<T> end() const { return {_end}; }
 
+    CC_FORCE_INLINE constexpr irange drop_first() const
+    {
+        CC_ASSERT(_begin != _end && "cannot drop from empty range");
+        auto r = *this; // copy
+        ++r._begin;
+        return r;
+    }
+    CC_FORCE_INLINE constexpr irange drop_last() const
+    {
+        CC_ASSERT(_begin != _end && "cannot drop from empty range");
+        auto r = *this; // copy
+        --r._end;
+        return r;
+    }
+
     CC_FORCE_INLINE constexpr rev_irange<T> reversed() const
     {
         auto b = _end;

--- a/src/clean-core/detail/srange.hh
+++ b/src/clean-core/detail/srange.hh
@@ -62,14 +62,14 @@ struct irange
     CC_FORCE_INLINE constexpr iiterator<T> begin() const { return {_begin}; }
     CC_FORCE_INLINE constexpr iiterator<T> end() const { return {_end}; }
 
-    CC_FORCE_INLINE constexpr irange drop_first() const
+    CC_FORCE_INLINE constexpr irange skip_first() const
     {
         CC_ASSERT(_begin != _end && "cannot drop from empty range");
         auto r = *this; // copy
         ++r._begin;
         return r;
     }
-    CC_FORCE_INLINE constexpr irange drop_last() const
+    CC_FORCE_INLINE constexpr irange skip_last() const
     {
         CC_ASSERT(_begin != _end && "cannot drop from empty range");
         auto r = *this; // copy

--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -7,6 +7,7 @@
 #include <type_traits>
 
 #include <clean-core/allocator.hh>
+#include <clean-core/allocators/system_allocator.hh>
 #include <clean-core/assert.hh>
 #include <clean-core/collection_traits.hh>
 #include <clean-core/detail/container_impl_util.hh>
@@ -39,12 +40,12 @@ struct vector_internals_with_allocator
 template <class T>
 struct vector_internals
 {
-    T* _alloc(size_t size) { return reinterpret_cast<T*>(cc::system_allocator->alloc(size * sizeof(T), alignof(T))); }
-    void _free(T* p) { cc::system_allocator->free(p); }
+    T* _alloc(size_t size) { return reinterpret_cast<T*>(cc::system_malloc(size * sizeof(T), alignof(T))); }
+    void _free(T* p) { cc::system_free(p); }
     T* _realloc(T* p, size_t size)
     {
         static_assert(std::is_trivially_copyable_v<T> && std::is_trivially_destructible_v<T>, "realloc not permitted for this type");
-        return reinterpret_cast<T*>(cc::system_allocator->realloc(p, size * sizeof(T), alignof(T)));
+        return reinterpret_cast<T*>(cc::system_realloc(p, size * sizeof(T), alignof(T)));
     }
 };
 
@@ -431,7 +432,7 @@ public:
     bool operator==(vector_base const& rhs) const noexcept { return operator==(span<T const>(rhs)); }
     bool operator!=(vector_base const& rhs) const noexcept { return operator!=(span<T const>(rhs)); }
 
-protected:
+public:
     void push_back_range_n(T const* data, size_t num)
     {
         if (!data || !num)

--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -156,10 +156,10 @@ public:
     T& push_back(T const& value)
     {
         static_assert(std::is_copy_constructible_v<T>, "only works with copyable types. did you forget a cc::move?");
-        return emplace_back(value);
+        return this->emplace_back(value);
     }
     /// adds an element at the end
-    T& push_back(T&& value) { return emplace_back(cc::move(value)); }
+    T& push_back(T&& value) { return this->emplace_back(cc::move(value)); }
 
     /// creates a new element at the end without growing
     template <class... Args>

--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -77,7 +77,7 @@ struct vector_internals
                 res = static_cast<std::byte*>(std::aligned_alloc(alignof(T), size * sizeof(T)));
 
                 if (p != nullptr)
-                    std::memcpy(res, p, cc::min(old_size, size * sizeof(T)));
+                    std::memcpy(res, p, cc::min(old_size * sizeof(T), size * sizeof(T)));
             }
 
             std::free(p);

--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -163,7 +163,7 @@ public:
 
     /// creates a new element at the end without growing
     template <class... Args>
-    T& emplace_back_stable(Args&&... args)
+    CC_FORCE_INLINE T& emplace_back_stable(Args&&... args)
     {
         CC_ASSERT(_size < _capacity && "At capacity");
         return *(new (placement_new, &_data[_size++]) T(cc::forward<Args>(args)...));

--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -169,16 +169,6 @@ public:
         return *(new (placement_new, &_data[_size++]) T(cc::forward<Args>(args)...));
     }
 
-    void push_back_range_n(T const* data, size_t num)
-    {
-        if (!data || !num)
-            return;
-
-        reserve(_size + num);
-        detail::container_copy_construct_range<T>(data, num, &_data[_size]);
-        _size += num;
-    }
-
     /// adds all elements of the range
     template <class Range>
     void push_back_range(Range&& range)
@@ -450,6 +440,17 @@ public:
 
     bool operator==(vector_base const& rhs) const noexcept { return operator==(span<T const>(rhs)); }
     bool operator!=(vector_base const& rhs) const noexcept { return operator!=(span<T const>(rhs)); }
+
+protected:
+    void push_back_range_n(T const* data, size_t num)
+    {
+        if (!data || !num)
+            return;
+
+        reserve(_size + num);
+        detail::container_copy_construct_range<T>(data, num, &_data[_size]);
+        _size += num;
+    }
 
     // members
 protected:

--- a/src/clean-core/detail/vector_base.hh
+++ b/src/clean-core/detail/vector_base.hh
@@ -270,6 +270,7 @@ public:
         _size = new_size;
     }
 
+    /// CAUTION: currently default_value must not be an interior reference
     void resize(size_t new_size, T const& default_value)
     {
         if (new_size > _capacity)

--- a/src/clean-core/experimental/chunked_buffer.hh
+++ b/src/clean-core/experimental/chunked_buffer.hh
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <clean-core/macros.hh>
+#include <clean-core/new.hh>
+#include <clean-core/span.hh>
+#include <clean-core/vector.hh>
+
+namespace cc
+{
+/// a chunk based buffer of values
+/// basically a more efficient vector<T> where only push_back and for-each is allowed
+/// there is no exponential resize involved
+/// push_back is always O(1)
+/// the main use case is accumulating output data, then iterating over it, no random access involved
+///
+/// TODO: maybe this can be cc::deque
+///       but without subscript access (maybe via explicit fun)
+///
+/// TODO: for now, this is non-moveable (because I'm lazy). eventually this is copyable
+/// TODO: for now, only chunk iteration is allowed
+/// TODO: make chunk size exponentially increasing for a while so that small buffers are more efficient?
+///       -> maybe userdefined is strict better
+template <class T>
+struct chunked_buffer
+{
+    size_t size() const { return _full_size + (_curr.head - _curr.begin); }
+    bool empty() const { return size() == 0; }
+
+    // TODO: might be able to formulate it so that f is only called once
+    // F: (span<T>) -> void
+    template <class F>
+    void for_each_chunk(F&& f)
+    {
+        for (auto const& c : _full_chunks)
+            f(c.as_span());
+        if (_curr.is_valid())
+            f(_curr.as_span());
+    }
+    // F: (span<T const>) -> void
+    template <class F>
+    void for_each_chunk(F&& f) const
+    {
+        for (auto const& c : _full_chunks)
+            f(c.as_const_span());
+        if (_curr.is_valid())
+            f(_curr.as_const_span());
+    }
+
+    template <class... Args>
+    T& emplace_back(Args&&... args)
+    {
+        // need new chunk?
+        if CC_CONDITION_UNLIKELY (!_curr.is_valid())
+        {
+            if (_curr.begin != nullptr)
+            {
+                _full_size += _curr.head - _curr.begin;
+                _full_chunks.push_back(_curr);
+            }
+
+            _curr.begin = _alloc(_chunk_size);
+            _curr.head = _curr.begin;
+            _curr.end = _curr.begin + _chunk_size;
+        }
+
+        CC_ASSERT(_curr.is_valid());
+        return *new (cc::placement_new, _curr.head++) T(cc::forward<Args>(args)...);
+    }
+    /// adds an element at the end
+    T& push_back(T const& value)
+    {
+        static_assert(std::is_copy_constructible_v<T>, "only works with copyable types. did you forget a cc::move?");
+        return this->emplace_back(value);
+    }
+    /// adds an element at the end
+    T& push_back(T&& value) { return this->emplace_back(cc::move(value)); }
+
+    // TODO: begin/end (really? is slow-ish)
+    // TODO: .chunks()
+    // TODO: .elements() -> if no begin/end
+    // TODO: push/pop front/back all
+
+    size_t chunk_size() const { return _chunk_size; }
+    void set_chunk_size(size_t s)
+    {
+        CC_ASSERT(s > 0);
+        _chunk_size = s;
+    }
+
+    chunked_buffer() = default;
+    chunked_buffer(chunked_buffer const&) = delete;
+    chunked_buffer& operator=(chunked_buffer const&) = delete;
+
+    ~chunked_buffer()
+    {
+        if (_curr.begin)
+            _free(_curr.begin);
+        for (auto const& c : _full_chunks)
+            _free(c.begin);
+    }
+
+private:
+    // TODO: use a doubly linked list for deque with push/pop front/back
+
+    static T* _alloc(size_t size) { return reinterpret_cast<T*>(new std::byte[size * sizeof(T)]); }
+    static void _free(T* p) { delete[] reinterpret_cast<std::byte*>(p); }
+
+    struct chunk
+    {
+        T* head = nullptr;
+        T* end = nullptr;
+        T* begin = nullptr;
+
+        bool is_valid() const { return head != end; }
+        cc::span<T> as_span() const { return {begin, head}; }
+        cc::span<T const> as_const_span() const { return {begin, head}; }
+    };
+
+    chunk _curr;
+    cc::vector<chunk> _full_chunks;
+    size_t _full_size = 0;
+    size_t _chunk_size = 1024; // elements
+};
+}

--- a/src/clean-core/experimental/disjoint_set.hh
+++ b/src/clean-core/experimental/disjoint_set.hh
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <clean-core/vector.hh>
+
+namespace cc
+{
+/// a union-find data structure with size-based path compression
+/// elements are numbered 0..size-1
+/// this class manages a disjoint collection of sets, each element belonging to exactly one set
+/// a set is characterized by its representative, which is an arbitrary element from the set
+///
+/// in the literature, this is often called a union-find data structure
+/// 'find' corresponds to get_representative
+/// 'union' corresponds to merge_sets_by_element / merge_sets_by_representative
+///
+/// NOTE: even seemingly readonly functions are non-const because
+///       the get_representative operation optimizes the data structure for optimal runtime
+struct disjoint_set
+{
+public:
+    disjoint_set() = default;
+
+    explicit disjoint_set(size_t size) { init(size); }
+
+    /// number of elements
+    size_t number_of_elements() const { return entries.size(); }
+    size_t number_of_partitions() const { return partition_count; }
+
+    /// initialized a disjoint set for a given number of entries
+    /// in the beginning, all entries are singleton sets
+    void init(size_t size)
+    {
+        entries.resize(size);
+        partition_count = size;
+
+        for (auto i = 0; i < int(size); ++i)
+        {
+            auto& e = entries[i];
+            e.parent = i;
+            e.size = 1;
+        }
+    }
+
+    /// returns the size of the set that e belongs to
+    int size_of_set_by_element(int e) { return entries[get_representative(e)].size; }
+
+    /// returns the size of the set that e_repr is the representative of
+    /// NOTE: e_repr must be the representative element
+    int size_of_set_by_representative(int e_repr)
+    {
+        CC_ASSERT(is_representative(e_repr));
+        return entries[e_repr].size;
+    }
+
+    /// returns true iff e is the representative of its set
+    bool is_representative(int e) { return get_representative(e) == e; }
+
+    /// returns true iff e0 and e1 belong to the same set
+    bool are_in_same_set(int e0, int e1) { return get_representative(e0) == get_representative(e1); }
+
+    /// returns the representative element of the set that e belongs to
+    int get_representative(int e)
+    {
+        auto& ee = entries[e];
+        if (ee.parent != e)
+            ee.parent = get_representative(ee.parent);
+        return ee.parent;
+    }
+
+    /// merges the sets given by two arbitrary elements e0 and e1
+    /// returns true iff a merge was done (i.e. if e0 and e1 belonged to different sets)
+    bool merge_sets_by_element(int e0, int e1)
+    {
+        auto e0_repr = get_representative(e0);
+        auto e1_repr = get_representative(e1);
+        return merge_sets_by_representative(e0_repr, e1_repr);
+    }
+
+    /// merges the sets given by two representative elements
+    /// returns true iff a merge was done (i.e. if two different elements were provided)
+    bool merge_sets_by_representative(int e0_repr, int e1_repr)
+    {
+        CC_ASSERT(is_representative(e0_repr));
+        CC_ASSERT(is_representative(e1_repr));
+
+        if (e0_repr == e1_repr)
+            return false;
+
+        // union by size
+        if (entries[e0_repr].size < entries[e1_repr].size)
+            std::swap(e0_repr, e1_repr);
+        // |X| > |Y|
+
+        entries[e1_repr].parent = e0_repr;
+        entries[e0_repr].size += entries[e1_repr].size;
+        partition_count--;
+
+        return true;
+    }
+
+private:
+    struct entry
+    {
+        int parent;
+        int size;
+    };
+
+private:
+    cc::vector<entry> entries;
+    size_t partition_count = 0;
+};
+}

--- a/src/clean-core/experimental/filewatch.cc
+++ b/src/clean-core/experimental/filewatch.cc
@@ -283,7 +283,7 @@ public:
         threadAlive.store(false, std::memory_order_release);
 #ifdef __unix__
         if (inotify_rm_watch(unixFolder, unixWatch) == -1)
-            error() << "Failed to remove inotify watch";
+            std::cerr << "Failed to remove inotify watch" << std::endl;
 #elif defined _WIN32
         SetEvent(winCloseEvent);
 #endif

--- a/src/clean-core/experimental/filewatch.cc
+++ b/src/clean-core/experimental/filewatch.cc
@@ -34,6 +34,8 @@
 #include <cstdlib>
 
 // the next two are "bricked" in the sanitized version
+#undef FAR
+#undef NEAR
 #define FAR
 #define NEAR
 #include <PathCch.h>

--- a/src/clean-core/experimental/filewatch.cc
+++ b/src/clean-core/experimental/filewatch.cc
@@ -1,0 +1,443 @@
+#include "filewatch.hh"
+
+// TODO: clean up this implementation
+
+#include <clean-core/string.hh>
+
+#include <algorithm>
+#include <array>
+#include <codecvt>
+#include <iostream>
+#include <locale>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+// TODO: use cc::shared_ptr
+#include <memory>
+
+#ifdef __unix__
+#include <sys/inotify.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#endif // __unix__
+
+#ifdef _WIN32
+#include <clean-core/native/win32_sanitized.hh>
+
+#include <tchar.h>
+#include <cstdio>
+#include <cstdlib>
+
+// the next two are "bricked" in the sanitized version
+#define FAR
+#define NEAR
+#include <PathCch.h>
+#include <Shlwapi.h>
+#endif // WIN32
+
+namespace
+{
+static std::size_t constexpr bufferSize = 1024 * 256;
+
+
+#ifdef _WIN32
+DWORD const sListenFilters = FILE_NOTIFY_CHANGE_SECURITY | FILE_NOTIFY_CHANGE_CREATION | FILE_NOTIFY_CHANGE_LAST_ACCESS | FILE_NOTIFY_CHANGE_LAST_WRITE
+                             | FILE_NOTIFY_CHANGE_SIZE | FILE_NOTIFY_CHANGE_ATTRIBUTES | FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_FILE_NAME;
+
+#elif defined __unix__
+std::size_t constexpr sEventSize = (sizeof(struct inotify_event));
+#endif
+
+struct Monitor;
+struct Flag;
+
+
+std::vector<cc::unique_ptr<Monitor>> sMonitors;
+void onFlagDestruction(Flag* flag);
+
+struct Flag
+{
+private:
+    std::atomic_bool mChanged = {false};
+    friend class FileWatch;
+
+public:
+    ~Flag() { onFlagDestruction(this); }
+
+    bool isChanged() const { return mChanged.load(std::memory_order_relaxed); }
+    void clear() { mChanged.store(false, std::memory_order_relaxed); }
+
+    friend Monitor;
+};
+
+struct Monitor
+{
+public:
+    struct FileLocation
+    {
+        std::string directory;
+        std::string filename;
+
+        FileLocation(std::string const& directory, std::string const& filename) : directory(directory), filename(filename) {}
+    };
+
+    static const FileLocation getFileLocation(const std::string_view path)
+    {
+        const auto predict = [](char character) -> bool
+        {
+#ifdef _WIN32
+            return character == _T('\\') || character == _T('/');
+#elif __unix__ || __APPLE__
+            return character == '/';
+#endif // __unix__
+        };
+
+        const auto pivot = std::find_if(path.rbegin(), path.rend(), predict).base();
+        // if the path is something like "test.txt" there will be no directoy part, however we still need one, so insert './'
+        const std::string directory = [&]()
+        {
+            const auto extracted_directory = std::string(path.begin(), pivot);
+            return (extracted_directory.size() > 0) ? extracted_directory : "./";
+        }();
+        const std::string filename = std::string(pivot, path.end());
+        return FileLocation(directory, filename);
+    }
+
+    struct FileEntry
+    {
+        FileLocation path;
+        std::weak_ptr<Flag> weakPtr;
+        Flag* rawPtr;
+
+        FileEntry(FileLocation const& path, std::weak_ptr<Flag> weak, Flag* ptr) : path(path), weakPtr(weak), rawPtr(ptr) {}
+    };
+
+private:
+    std::string path; // the path watched by this monitor
+
+    std::mutex fileMutex;
+    std::vector<FileEntry> files; // the files relevant to this monitor
+
+    std::thread thread;
+    std::atomic_bool threadAlive = {true};
+
+    // == platform specifics ==
+#ifdef __unix__
+    int unixFolder;
+    int unixWatch;
+#elif defined _WIN32
+    HANDLE winCloseEvent;
+    HANDLE winDirectory;
+#endif
+
+private:
+    void launch()
+    {
+        thread = std::thread(
+            [this]()
+            {
+
+        // == Native Setup ==
+#if defined __unix__
+                std::array<char, bufferSize> buffer;
+#elif defined _WIN32
+                std::array<BYTE, bufferSize> buffer;
+                DWORD bytesReturned = 0;
+                OVERLAPPED overlappedBuffer;
+                overlappedBuffer.hEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+                CC_ASSERT(!!overlappedBuffer.hEvent && "Failed to create Win32 monitor event");
+
+                std::array<HANDLE, 2> handles = {overlappedBuffer.hEvent, this->winCloseEvent};
+                auto asyncPending = false;
+#endif
+
+                while (this->threadAlive.load(std::memory_order_acquire))
+                {
+                // == Native Loop Body ==
+#ifdef __unix__
+                    auto const length = read(this->unixFolder, static_cast<void*>(buffer.data()), buffer.size());
+
+                    if (length > 0)
+                    {
+                        int i = 0;
+                        while (i < length)
+                        {
+                            inotify_event* event = reinterpret_cast<inotify_event*>(&buffer[size_t(i)]);
+                            if (event->len /*&& (event->mask & IN_CREATE || event->mask & IN_MODIFY)*/)
+                            {
+                                FileLocation changedFile = getFileLocation(std::string(event->name));
+
+                                // Loop over every registered file
+                                {
+                                    std::lock_guard<std::mutex> lock(this->fileMutex);
+                                    for (auto const& file : this->files)
+                                        if (changedFile.filename == file.path.filename)
+                                        {
+                                            file.rawPtr->mChanged.store(true, std::memory_order_release);
+                                            break;
+                                        }
+                                }
+                            }
+                            i += sEventSize + event->len;
+                        }
+                    }
+
+#elif defined _WIN32
+                    ReadDirectoryChangesW(this->winDirectory, buffer.data(), static_cast<DWORD>(buffer.size()), TRUE, sListenFilters, &bytesReturned,
+                                          &overlappedBuffer, nullptr);
+
+                    asyncPending = true;
+
+                    auto res = WaitForMultipleObjects(2, handles.data(), FALSE, INFINITE);
+
+                    if (res == WAIT_OBJECT_0)
+                    {
+                        auto overlapResultSuccess = GetOverlappedResult(this->winDirectory, &overlappedBuffer, &bytesReturned, TRUE);
+                        CC_ASSERT(overlapResultSuccess && "Call to GetOverlappedResult failed");
+                        asyncPending = false;
+
+                        if (bytesReturned == 0)
+                            continue;
+
+                        FILE_NOTIFY_INFORMATION* fileInfo = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(&buffer[0]);
+                        if (fileInfo->Action == FILE_ACTION_MODIFIED)
+                        {
+                            // Loop over every entry in the fileInfo
+                            for (;;)
+                            {
+                                FileLocation changedFile = getFileLocation(std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>().to_bytes(
+                                    std::wstring(fileInfo->FileName, fileInfo->FileNameLength / 2)));
+
+                                // Loop over every registered file
+                                {
+                                    std::lock_guard<std::mutex> lock(this->fileMutex);
+                                    for (auto const& file : this->files)
+                                        if (changedFile.filename == file.path.filename)
+                                        {
+                                            file.rawPtr->mChanged.store(true, std::memory_order_release);
+                                            // break;
+                                        }
+                                }
+
+                                if (fileInfo->NextEntryOffset == 0)
+                                    break;
+
+                                fileInfo = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(reinterpret_cast<BYTE*>(fileInfo) + fileInfo->NextEntryOffset);
+                            }
+                        }
+                    }
+#endif
+                }
+
+            // == Native Cleanup ==
+#ifdef __unix__
+                close(this->unixFolder);
+#elif defined _WIN32
+                if (asyncPending)
+                {
+                    CancelIo(this->winDirectory);
+                    GetOverlappedResult(this->winDirectory, &overlappedBuffer, &bytesReturned, TRUE);
+                }
+
+                CloseHandle(this->winDirectory);
+#endif
+            });
+    }
+
+public:
+#ifdef __unix__
+    Monitor(std::string path, int folder, int watch) : path(std::move(path)), unixFolder(folder), unixWatch(watch) { launch(); }
+#elif defined _WIN32
+    Monitor(std::string path, HANDLE close, HANDLE dir) : path(std::move(path)), winCloseEvent(close), winDirectory(dir) { launch(); }
+#endif
+
+    static cc::unique_ptr<Monitor> create(std::string const& path)
+    {
+#ifdef __unix__
+        auto unixFolder = inotify_init();
+        CC_ASSERT(unixFolder >= 0 && "Failed to initialize inotify");
+        auto unixWatch = inotify_add_watch(unixFolder, path.c_str(), IN_MODIFY | IN_CREATE);
+        CC_ASSERT(unixWatch >= 0 && "Failed to create inotify watch");
+
+        return cc::make_unique<Monitor>(path, unixFolder, unixWatch);
+#elif defined _WIN32
+        auto winCloseEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+        CC_ASSERT(!!winCloseEvent && "Failed to create Win32 close event");
+        auto winDirectory = ::CreateFile(path.c_str(), FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+                                         OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, nullptr);
+        CC_ASSERT(winDirectory != INVALID_HANDLE_VALUE && "Failed to create Win32 directory handle");
+
+        return cc::make_unique<Monitor>(path, winCloseEvent, winDirectory);
+#elif defined __APPLE__
+        return {};
+#endif
+    }
+
+    ~Monitor()
+    {
+        threadAlive.store(false, std::memory_order_release);
+#ifdef __unix__
+        if (inotify_rm_watch(unixFolder, unixWatch) == -1)
+            error() << "Failed to remove inotify watch";
+#elif defined _WIN32
+        SetEvent(winCloseEvent);
+#endif
+        thread.join();
+    }
+
+    // add a file to the watchlist if the monitor can accomodate it
+    bool add(FileEntry const& file)
+    {
+        if (file.path.directory == path)
+        {
+            // This file is inside this folder (top-level), add it to the list
+            std::lock_guard<std::mutex> lock(fileMutex);
+            files.push_back(file);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    // removes a file to watch if on the watchlist
+    bool remove(Flag* flag)
+    {
+        for (auto it = files.begin(); it != files.end(); ++it)
+            if (it->rawPtr == flag)
+            {
+                std::lock_guard<std::mutex> lock(fileMutex);
+                files.erase(it);
+                return true;
+            }
+
+        return false;
+    }
+
+    bool isEmpty() const { return files.empty(); }
+
+    // Returns the the locked flag for a given filename, or nullptr if this monitor does not contain it
+    std::shared_ptr<Flag> getFlag(FileLocation const& path)
+    {
+        for (auto it = files.begin(); it != files.end(); ++it)
+        {
+            if (it->path.directory == path.directory && it->path.filename == path.filename)
+            {
+                // info() << "Aliased " << path.filename;
+                std::lock_guard<std::mutex> lock(fileMutex);
+                return it->weakPtr.lock(); // Any weak_ptr in files is not expired
+            }
+        }
+
+        return nullptr;
+    }
+};
+
+void onFlagDestruction(Flag* flag)
+{
+    // Erase the flag from its monitor
+    // TODO: We could figure out which monitor is responsible instead of brute-forcing here
+    for (auto it = sMonitors.begin(); it != sMonitors.end(); ++it)
+    {
+        auto const& mon = *it;
+        if (mon->remove(flag))
+        {
+            // If this was the last file of that monitor, destroy it
+            if (mon->isEmpty())
+                sMonitors.erase(it);
+
+            // This is a search, the file is only part of a single monitor
+            break;
+        }
+    }
+}
+
+std::shared_ptr<Flag> createFileWatchFlag(cc::string_view filename, bool forceUnique)
+{
+    auto path = Monitor::getFileLocation(std::string_view(filename.data(), filename.size()));
+
+    if (!forceUnique)
+    {
+        // Check if the file already exists, if yes return an aliased shared_ptr
+        for (auto const& monitor : sMonitors)
+        {
+            auto flag = monitor->getFlag(path);
+            if (flag)
+                return flag;
+        }
+    }
+
+    // Create a new watch
+    {
+        auto watcher = std::make_shared<Flag>();
+        Monitor::FileEntry entry = {path, watcher, watcher.get()};
+
+        // See if any monitor is compatible
+        bool foundExistingMonitor = false;
+        for (auto const& mon : sMonitors)
+        {
+            if (mon->add(entry))
+            {
+                foundExistingMonitor = true;
+                break;
+            }
+        }
+
+        // Create a new monitor
+        if (!foundExistingMonitor)
+        {
+            auto newMonitor = Monitor::create(entry.path.directory);
+            if (newMonitor == nullptr)
+            {
+                std::cerr << "Failed to watch " << cc::string(filename).c_str() << " for hotreloading" << std::endl;
+#ifdef __unix__
+                std::cerr << "Consider increasing inotify watch limits: " << std::endl;
+                std::cerr << "$ echo 16384 | sudo tee /proc/sys/fs/inotify/max_user_watches" << std::endl;
+#endif
+            }
+            else
+            {
+                auto success = newMonitor->add(entry);
+                // This should never fail
+                CC_ASSERT(success && "Fatal: Freshly created monitor cannot accomodate provoking file");
+                sMonitors.push_back(std::move(newMonitor));
+            }
+        }
+
+        return watcher;
+    }
+}
+
+}
+
+struct cc::filewatch::state
+{
+    std::shared_ptr<Flag> flag;
+};
+
+bool cc::filewatch::has_changed() const { return _state != nullptr && _state->flag->isChanged(); }
+
+void cc::filewatch::set_unchanged()
+{
+    CC_ASSERT(is_valid() && "cannot reset an invalid filewatch");
+    _state->flag->clear();
+}
+
+cc::filewatch cc::filewatch::create(cc::string_view filename)
+{
+    filewatch fw;
+    fw._state = cc::make_unique<state>();
+    fw._state->flag = createFileWatchFlag(filename, true); // TODO: expose non-unique feature?
+    return fw;
+}
+
+cc::filewatch::filewatch() = default;
+cc::filewatch::filewatch(cc::filewatch&&) = default;
+cc::filewatch& cc::filewatch::operator=(cc::filewatch&&) noexcept = default;
+cc::filewatch::~filewatch() = default;

--- a/src/clean-core/experimental/filewatch.hh
+++ b/src/clean-core/experimental/filewatch.hh
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <atomic>
+
+#include <clean-core/string_view.hh>
+#include <clean-core/unique_ptr.hh>
+#include <clean-core/vector.hh>
+
+namespace cc
+{
+/**
+ * Watch files on disk for changes
+ *
+ * Usage:
+ *
+ *     auto watch = cc::filewatch::create(path);
+ *
+ *     // time passes...
+ *
+ *     if (watch.has_changed())
+ *     {
+ *         // reload resource..
+ *          watch.set_unchanged();
+ *     }
+ *
+ * NOTE:
+ *   this class is move-only
+ */
+struct filewatch
+{
+public:
+    /// returns true iff this watches a file
+    bool is_valid() const { return _state != nullptr; }
+
+    /// returns true iff the watch is valid and the watched file has changed
+    bool has_changed() const;
+
+    /// clears the "has_changed" status
+    void set_unchanged();
+
+    /// creates a filewatch for a specific path
+    static filewatch create(cc::string_view filename);
+
+    filewatch();
+    filewatch(filewatch&&);
+    filewatch& operator=(filewatch&&) noexcept;
+    filewatch(filewatch const&) = delete;
+    filewatch& operator=(filewatch const&) = delete;
+    ~filewatch();
+
+private:
+    struct state;
+    cc::unique_ptr<state> _state;
+};
+}

--- a/src/clean-core/experimental/flat_vector_of_vector.hh
+++ b/src/clean-core/experimental/flat_vector_of_vector.hh
@@ -1,0 +1,130 @@
+#pragma once
+
+#include <clean-core/sentinel.hh>
+#include <clean-core/span.hh>
+#include <clean-core/vector.hh>
+
+namespace cc
+{
+namespace detail
+{
+template <class T, class IndexT>
+struct flat_vector_of_vector_iterator;
+}
+
+/// an efficient, array-embedded version of vector<vector<T>>
+/// as a range, behaves like [span<T>]
+/// IndexT points into the inner vector
+template <class T, class IndexT = size_t>
+struct flat_vector_of_vector
+{
+    using index_t = IndexT;
+
+    // container
+public:
+    size_t size() const { return _start_idx.size(); }
+    bool empty() const { return _start_idx.empty(); }
+
+    cc::span<IndexT> start_indices() { return _start_idx; }
+    cc::span<IndexT const> start_indices() const { return _start_idx; }
+
+    cc::span<T> elements() { return _elements; }
+    cc::span<T const> elements() const { return _elements; }
+
+    cc::span<T> operator[](size_t i)
+    {
+        CC_CONTRACT(size_t(i) < _start_idx.size());
+        auto start_idx = _start_idx[i];
+        auto end_idx = i + 1 == _start_idx.size() ? _elements.size() : _start_idx[i + 1];
+        return {_elements.data() + start_idx, _elements.data() + end_idx};
+    }
+    cc::span<T const> operator[](size_t i) const
+    {
+        CC_CONTRACT(size_t(i) < _start_idx.size());
+        auto start_idx = _start_idx[i];
+        auto end_idx = i + 1 == _start_idx.size() ? _elements.size() : _start_idx[i + 1];
+        return {_elements.data() + start_idx, _elements.data() + end_idx};
+    }
+
+    // mutation
+public:
+    void start_new_range() { _start_idx.push_back(index_t(_elements.size())); }
+
+    /// adds an element to the last range
+    template <class... Args>
+    T& emplace_back_element(Args&&... args)
+    {
+        CC_ASSERT(!_start_idx.empty() && "no ranges present. did you forget to call start_new_range()?");
+        return _elements.emplace_back(cc::forward<Args>(args)...);
+    }
+    /// adds an element to the last range
+    T& push_back_element(T const& value)
+    {
+        static_assert(std::is_copy_constructible_v<T>, "only works with copyable types. did you forget a cc::move?");
+        return emplace_back_element(value);
+    }
+    /// adds an element to the last range
+    T& push_back_element(T&& value) { return emplace_back_element(cc::move(value)); }
+
+    /// adds all range elements to the last range
+    /// NOTE: does NOT start a new range before
+    template <class Range>
+    void push_back_elements(Range&& range)
+    {
+        CC_ASSERT(!_start_idx.empty() && "no ranges present. did you forget to call start_new_range()?");
+        _elements.push_back_range(cc::forward<Range>(range));
+    }
+
+    void clear()
+    {
+        _elements.clear();
+        _start_idx.clear();
+    }
+    void reserve_elements(size_t capacity) { _elements.reserve(capacity); }
+    void reserve_ranges(size_t capacity) { _start_idx.reserve(capacity); }
+
+    // iteration
+public:
+    detail::flat_vector_of_vector_iterator<T, index_t> begin()
+    {
+        return {_elements.data(), _elements.data() + _elements.size(), _start_idx.data(), _start_idx.data() + _start_idx.size()};
+    }
+    detail::flat_vector_of_vector_iterator<T const, index_t> begin() const
+    {
+        return {_elements.data(), _elements.data() + _elements.size(), _start_idx.data(), _start_idx.data() + _start_idx.size()};
+    }
+    cc::sentinel end() const { return {}; }
+
+private:
+    cc::vector<T> _elements;
+    cc::vector<index_t> _start_idx; // TODO: maybe "last idx" has better codegen?
+};
+
+namespace detail
+{
+template <class T, class IndexT>
+struct flat_vector_of_vector_iterator
+{
+    flat_vector_of_vector_iterator() = default;
+    flat_vector_of_vector_iterator(T* element_data, T* element_end, IndexT const* curr_idx, IndexT const* end_idx)
+      : _element_data(element_data), _element_end(element_end), _curr_idx(curr_idx), _end_idx(end_idx)
+    {
+    }
+
+    bool operator!=(cc::sentinel) const { return _curr_idx != _end_idx; }
+    void operator++() { ++_curr_idx; }
+    cc::span<T> operator*() const
+    {
+        auto e_start = _element_data + *_curr_idx;
+        auto e_end = _curr_idx + 1 == _end_idx ? _element_end : _element_data + *(_curr_idx + 1);
+        return {e_start, e_end};
+    }
+
+private:
+    T* _element_data;
+    T* _element_end;
+    IndexT const* _curr_idx;
+    IndexT const* _end_idx;
+};
+}
+}

--- a/src/clean-core/experimental/mpmc_queue.hh
+++ b/src/clean-core/experimental/mpmc_queue.hh
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <atomic>
+
+#include <clean-core/alloc_array.hh>
+#include <clean-core/assert.hh>
+#include <clean-core/bits.hh>
+
+namespace cc
+{
+// Multi-Producer/Multi-Consumer Queue
+// FIFO
+// ~75 cycles per enqueue and dequeue under contention
+// Adapted from http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
+template <class T>
+struct mpmc_queue
+{
+public:
+    mpmc_queue() = default;
+    explicit mpmc_queue(size_t num_elements, cc::allocator* allocator) { initialize(num_elements, allocator); }
+
+    void initialize(size_t num_elements, cc::allocator* allocator)
+    {
+        CC_ASSERT(num_elements >= 2 && cc::is_pow2(num_elements) && "mpmc_queue size not a power of two");
+
+        _buffer_mask = num_elements - 1;
+        _buffer.reset(allocator, num_elements);
+        for (size_t i = 0; i < num_elements; ++i)
+        {
+            _buffer[i].sequence_.store(i, std::memory_order_relaxed);
+        }
+
+        _enqueue_pos.store(0, std::memory_order_relaxed);
+        _dequeue_pos.store(0, std::memory_order_relaxed);
+    }
+
+    bool enqueue(const T& data)
+    {
+        cell* cell;
+        size_t pos = _enqueue_pos.load(std::memory_order_relaxed);
+        for (;;)
+        {
+            cell = &_buffer[pos & _buffer_mask];
+            size_t seq = cell->sequence_.load(std::memory_order_acquire);
+            intptr_t diff = static_cast<intptr_t>(seq) - static_cast<intptr_t>(pos);
+            if (diff == 0)
+            {
+                if (_enqueue_pos.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed))
+                    break;
+            }
+            else if (diff < 0)
+                return false;
+            else
+                pos = _enqueue_pos.load(std::memory_order_relaxed);
+        }
+        cell->data_ = data;
+        cell->sequence_.store(pos + 1, std::memory_order_release);
+        return true;
+    }
+
+    bool dequeue(T* out_data)
+    {
+        cell* cell;
+        size_t pos = _dequeue_pos.load(std::memory_order_relaxed);
+        for (;;)
+        {
+            cell = &_buffer[pos & _buffer_mask];
+            size_t seq = cell->sequence_.load(std::memory_order_acquire);
+            intptr_t diff = static_cast<intptr_t>(seq) - static_cast<intptr_t>(pos + 1);
+            if (diff == 0)
+            {
+                if (_dequeue_pos.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed))
+                    break;
+            }
+            else if (diff < 0)
+                return false;
+            else
+                pos = _dequeue_pos.load(std::memory_order_relaxed);
+        }
+        *out_data = cell->data_;
+        cell->sequence_.store(pos + _buffer_mask + 1, std::memory_order_release);
+        return true;
+    }
+
+private:
+    struct cell
+    {
+        std::atomic<size_t> sequence_;
+        T data_;
+    };
+
+    using cacheline_pad_t = char[64];
+
+    cacheline_pad_t _pad0;
+
+    cc::alloc_array<cell> _buffer;
+    size_t _buffer_mask = 0;
+
+    cacheline_pad_t _pad1;
+
+    std::atomic<size_t> _enqueue_pos = {0};
+
+    cacheline_pad_t _pad2;
+
+    std::atomic<size_t> _dequeue_pos = {0};
+
+    cacheline_pad_t _pad3;
+
+    mpmc_queue(mpmc_queue const& other) = delete;
+    mpmc_queue(mpmc_queue&& other) noexcept = delete;
+    mpmc_queue& operator=(mpmc_queue const& other) = delete;
+    mpmc_queue& operator=(mpmc_queue&& other) noexcept = delete;
+};
+}

--- a/src/clean-core/experimental/pimpl.hh
+++ b/src/clean-core/experimental/pimpl.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <clean-core/fwd_box.hh>
+#include <clean-core/experimental/fwd_box.hh>
 
 namespace cc
 {

--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -46,7 +46,7 @@ struct has_to_string_args_t : std::false_type
 {
 };
 template <class T>
-struct has_to_string_args_t<T, std::void_t<decltype(string_view(o_string(std::declval<T>(), std::declval<string_view>())))>> : std::true_type
+struct has_to_string_args_t<T, std::void_t<decltype(string_view(to_string(std::declval<T>(), std::declval<string_view>())))>> : std::true_type
 {
 };
 template <class T>

--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -113,6 +113,17 @@ template <class T>
 constexpr bool has_to_string = has_to_string_t<T>::value;
 
 template <class T, class = std::void_t<>>
+struct has_member_toStdString_t : std::false_type
+{
+};
+template <class T>
+struct has_member_toStdString_t<T, std::void_t<decltype(string_view(std::declval<T>().toStdString()))>> : std::true_type
+{
+};
+template <class T>
+constexpr bool has_member_toStdString = has_member_toStdString_t<T>::value;
+
+template <class T, class = std::void_t<>>
 struct has_member_to_string_t : std::false_type
 {
 };
@@ -157,6 +168,10 @@ struct default_do_format
         else if constexpr (detail::has_member_to_string<T>)
         {
             s << string_view(v.to_string());
+        }
+        else if constexpr (detail::has_member_toStdString<T>)
+        {
+            s << string_view(v.toStdString());
         }
         else
         {

--- a/src/clean-core/format.hh
+++ b/src/clean-core/format.hh
@@ -40,15 +40,15 @@ struct pythonic_formatter;
 ///   auto s = cc::format("{.2f} %6d", 1.234, 1000);
 ///
 template <class Formatter = detail::default_formatter, class... Args>
-string format(char const* fmt_str, Args const&... args);
+[[nodiscard]] string format(char const* fmt_str, Args const&... args);
 
 /// same as cc::format but only uses printf-style % syntax (with the generic %s)
 template <class... Args>
-string formatf(char const* fmt_str, Args const&... args);
+[[nodiscard]] string formatf(char const* fmt_str, Args const&... args);
 
 /// same as cc::format but only uses pythonic {} syntax
 template <class... Args>
-string formatp(char const* fmt_str, Args const&... args);
+[[nodiscard]] string formatp(char const* fmt_str, Args const&... args);
 
 /// version of cc::format that appends the result to a stream or string
 /// this is usually a bit more efficient than cc::format

--- a/src/clean-core/forward.hh
+++ b/src/clean-core/forward.hh
@@ -1,16 +1,17 @@
 #pragma once
 
 #include <clean-core/detail/remove_reference.hh>
+#include <clean-core/macros.hh>
 
 namespace cc
 {
 template <class T>
-constexpr T&& forward(remove_reference<T>& t) noexcept
+CC_FORCE_INLINE constexpr T&& forward(remove_reference<T>& t) noexcept
 {
     return static_cast<T&&>(t);
 }
 template <class T>
-constexpr T&& forward(remove_reference<T>&& t) noexcept
+CC_FORCE_INLINE constexpr T&& forward(remove_reference<T>&& t) noexcept
 {
     return static_cast<T&&>(t);
 }

--- a/src/clean-core/from_string.cc
+++ b/src/clean-core/from_string.cc
@@ -209,6 +209,6 @@ bool cc::from_string(string_view str, std::byte& out_value)
     if (i0 == -1 || i1 == -1)
         return false;
 
-    out_value = std::byte((i1 << 4) + i0);
+    out_value = std::byte((i0 << 4) + i1);
     return true;
 }

--- a/src/clean-core/from_string.cc
+++ b/src/clean-core/from_string.cc
@@ -184,3 +184,31 @@ bool cc::from_string(cc::string_view str, bool& v)
     else
         return false;
 }
+
+bool cc::from_string(string_view str, std::byte& out_value)
+{
+    if (str.size() != 2)
+        return false;
+
+    auto hex_from_char = [](char c) -> int
+    {
+        if ('0' <= c && c <= '9')
+            return c - '0';
+
+        if ('a' <= c && c <= 'f')
+            return 10 + (c - 'a');
+
+        if ('A' <= c && c <= 'F')
+            return 10 + (c - 'A');
+
+        return -1;
+    };
+
+    auto i0 = hex_from_char(str[0]);
+    auto i1 = hex_from_char(str[1]);
+    if (i0 == -1 || i1 == -1)
+        return false;
+
+    out_value = std::byte((i1 << 4) + i0);
+    return true;
+}

--- a/src/clean-core/from_string.hh
+++ b/src/clean-core/from_string.hh
@@ -37,4 +37,7 @@ namespace cc
 
 [[nodiscard]] bool from_string(cc::string_view str, float& out_value);
 [[nodiscard]] bool from_string(cc::string_view str, double& out_value);
+
+// 2 chars hex, e.g. "FF" or "1A"
+[[nodiscard]] bool from_string(cc::string_view str, std::byte& out_value);
 }

--- a/src/clean-core/fwd.hh
+++ b/src/clean-core/fwd.hh
@@ -101,6 +101,8 @@ template <class T>
 struct unique_ptr;
 template <class T>
 struct poly_unique_ptr;
+template <class T>
+struct shared_ptr;
 
 // locks
 struct spin_lock;

--- a/src/clean-core/fwd.hh
+++ b/src/clean-core/fwd.hh
@@ -24,6 +24,8 @@ struct equal_to;
 struct nullopt_t;
 template <class T>
 struct optional;
+template <class... Types>
+struct variant;
 
 template <class A, class B>
 struct pair;

--- a/src/clean-core/hash.hh
+++ b/src/clean-core/hash.hh
@@ -84,6 +84,8 @@ static constexpr bool can_hash = detail::can_hash_t<T, Hasher>::value;
 
 // ============== make_hash ==============
 
+/// helper that creates a hash of all arguments that are passed
+/// uses cc::hash per default
 template <class Hasher = hash<void>, class... Args>
 constexpr uint64_t make_hash(Args const&... values) noexcept
 {

--- a/src/clean-core/hash.sha1.cc
+++ b/src/clean-core/hash.sha1.cc
@@ -1,0 +1,282 @@
+#include "hash.sha1.hh"
+
+#include <clean-core/bits.hh>
+
+// TODO: expose stream api at some point
+namespace
+{
+// impl loosely based on https://github.com/vog/sha1 (public domain)
+// and https://en.wikipedia.org/wiki/SHA-1
+// with significant performance improvements
+struct sha1_builder
+{
+    static constexpr size_t BLOCK_INTS = 16; /* number of 32bit integers per SHA1 block */
+    static constexpr size_t BLOCK_BYTES = BLOCK_INTS * 4;
+
+    uint32_t digest[5];
+    size_t total_size_in_bytes;
+
+    // tmp buffer
+    // size is 2 buffers so we can compute padding easily
+    std::byte buffer_block[BLOCK_BYTES * 2];
+    size_t buffer_size;
+
+    static uint32_t rol(const uint32_t value, const size_t bits) { return (value << bits) | (value >> (32 - bits)); }
+    static uint32_t blk(const uint32_t block[BLOCK_INTS], const size_t i)
+    {
+        return rol(block[(i + 13) & 15] ^ block[(i + 8) & 15] ^ block[(i + 2) & 15] ^ block[i], 1);
+    }
+
+    /*
+     * (R0+R1), R2, R3, R4 are the different operations used in SHA1
+     */
+
+    static void R0(const uint32_t block[BLOCK_INTS], const uint32_t v, uint32_t& w, const uint32_t x, const uint32_t y, uint32_t& z, const size_t i)
+    {
+        z += ((w & (x ^ y)) ^ y) + block[i] + 0x5a827999 + rol(v, 5);
+        w = rol(w, 30);
+    }
+
+    static void R1(uint32_t block[BLOCK_INTS], const uint32_t v, uint32_t& w, const uint32_t x, const uint32_t y, uint32_t& z, const size_t i)
+    {
+        block[i] = blk(block, i);
+        z += ((w & (x ^ y)) ^ y) + block[i] + 0x5a827999 + rol(v, 5);
+        w = rol(w, 30);
+    }
+
+    static void R2(uint32_t block[BLOCK_INTS], const uint32_t v, uint32_t& w, const uint32_t x, const uint32_t y, uint32_t& z, const size_t i)
+    {
+        block[i] = blk(block, i);
+        z += (w ^ x ^ y) + block[i] + 0x6ed9eba1 + rol(v, 5);
+        w = rol(w, 30);
+    }
+
+    static void R3(uint32_t block[BLOCK_INTS], const uint32_t v, uint32_t& w, const uint32_t x, const uint32_t y, uint32_t& z, const size_t i)
+    {
+        block[i] = blk(block, i);
+        z += (((w | x) & y) | (w & x)) + block[i] + 0x8f1bbcdc + rol(v, 5);
+        w = rol(w, 30);
+    }
+
+    static void R4(uint32_t block[BLOCK_INTS], const uint32_t v, uint32_t& w, const uint32_t x, const uint32_t y, uint32_t& z, const size_t i)
+    {
+        block[i] = blk(block, i);
+        z += (w ^ x ^ y) + block[i] + 0xca62c1d6 + rol(v, 5);
+        w = rol(w, 30);
+    }
+
+
+    /*
+     * Hash a single 512-bit block. This is the core of the algorithm.
+     */
+    void transform(std::byte buffer[BLOCK_BYTES])
+    {
+        // convert endianness
+        auto buffer_u32 = (uint32_t*)buffer;
+        uint32_t block[BLOCK_INTS];
+        for (size_t i = 0; i < BLOCK_INTS; ++i)
+            block[i] = cc::byteswap(buffer_u32[i]);
+
+        /* Copy digest[] to working vars */
+        uint32_t a = digest[0];
+        uint32_t b = digest[1];
+        uint32_t c = digest[2];
+        uint32_t d = digest[3];
+        uint32_t e = digest[4];
+
+        /* 4 rounds of 20 operations each. Loop unrolled. */
+        R0(block, a, b, c, d, e, 0);
+        R0(block, e, a, b, c, d, 1);
+        R0(block, d, e, a, b, c, 2);
+        R0(block, c, d, e, a, b, 3);
+        R0(block, b, c, d, e, a, 4);
+        R0(block, a, b, c, d, e, 5);
+        R0(block, e, a, b, c, d, 6);
+        R0(block, d, e, a, b, c, 7);
+        R0(block, c, d, e, a, b, 8);
+        R0(block, b, c, d, e, a, 9);
+        R0(block, a, b, c, d, e, 10);
+        R0(block, e, a, b, c, d, 11);
+        R0(block, d, e, a, b, c, 12);
+        R0(block, c, d, e, a, b, 13);
+        R0(block, b, c, d, e, a, 14);
+        R0(block, a, b, c, d, e, 15);
+        R1(block, e, a, b, c, d, 0);
+        R1(block, d, e, a, b, c, 1);
+        R1(block, c, d, e, a, b, 2);
+        R1(block, b, c, d, e, a, 3);
+        R2(block, a, b, c, d, e, 4);
+        R2(block, e, a, b, c, d, 5);
+        R2(block, d, e, a, b, c, 6);
+        R2(block, c, d, e, a, b, 7);
+        R2(block, b, c, d, e, a, 8);
+        R2(block, a, b, c, d, e, 9);
+        R2(block, e, a, b, c, d, 10);
+        R2(block, d, e, a, b, c, 11);
+        R2(block, c, d, e, a, b, 12);
+        R2(block, b, c, d, e, a, 13);
+        R2(block, a, b, c, d, e, 14);
+        R2(block, e, a, b, c, d, 15);
+        R2(block, d, e, a, b, c, 0);
+        R2(block, c, d, e, a, b, 1);
+        R2(block, b, c, d, e, a, 2);
+        R2(block, a, b, c, d, e, 3);
+        R2(block, e, a, b, c, d, 4);
+        R2(block, d, e, a, b, c, 5);
+        R2(block, c, d, e, a, b, 6);
+        R2(block, b, c, d, e, a, 7);
+        R3(block, a, b, c, d, e, 8);
+        R3(block, e, a, b, c, d, 9);
+        R3(block, d, e, a, b, c, 10);
+        R3(block, c, d, e, a, b, 11);
+        R3(block, b, c, d, e, a, 12);
+        R3(block, a, b, c, d, e, 13);
+        R3(block, e, a, b, c, d, 14);
+        R3(block, d, e, a, b, c, 15);
+        R3(block, c, d, e, a, b, 0);
+        R3(block, b, c, d, e, a, 1);
+        R3(block, a, b, c, d, e, 2);
+        R3(block, e, a, b, c, d, 3);
+        R3(block, d, e, a, b, c, 4);
+        R3(block, c, d, e, a, b, 5);
+        R3(block, b, c, d, e, a, 6);
+        R3(block, a, b, c, d, e, 7);
+        R3(block, e, a, b, c, d, 8);
+        R3(block, d, e, a, b, c, 9);
+        R3(block, c, d, e, a, b, 10);
+        R3(block, b, c, d, e, a, 11);
+        R4(block, a, b, c, d, e, 12);
+        R4(block, e, a, b, c, d, 13);
+        R4(block, d, e, a, b, c, 14);
+        R4(block, c, d, e, a, b, 15);
+        R4(block, b, c, d, e, a, 0);
+        R4(block, a, b, c, d, e, 1);
+        R4(block, e, a, b, c, d, 2);
+        R4(block, d, e, a, b, c, 3);
+        R4(block, c, d, e, a, b, 4);
+        R4(block, b, c, d, e, a, 5);
+        R4(block, a, b, c, d, e, 6);
+        R4(block, e, a, b, c, d, 7);
+        R4(block, d, e, a, b, c, 8);
+        R4(block, c, d, e, a, b, 9);
+        R4(block, b, c, d, e, a, 10);
+        R4(block, a, b, c, d, e, 11);
+        R4(block, e, a, b, c, d, 12);
+        R4(block, d, e, a, b, c, 13);
+        R4(block, c, d, e, a, b, 14);
+        R4(block, b, c, d, e, a, 15);
+
+        /* Add the working vars back into digest[] */
+        digest[0] += a;
+        digest[1] += b;
+        digest[2] += c;
+        digest[3] += d;
+        digest[4] += e;
+    }
+
+
+    void reset()
+    {
+        /* SHA1 initialization constants */
+        digest[0] = 0x67452301;
+        digest[1] = 0xefcdab89;
+        digest[2] = 0x98badcfe;
+        digest[3] = 0x10325476;
+        digest[4] = 0xc3d2e1f0;
+
+        /* Reset counters */
+        total_size_in_bytes = 0;
+        buffer_size = 0;
+    }
+
+    void update(cc::span<std::byte const> data)
+    {
+        total_size_in_bytes += data.size_bytes();
+
+        while (true)
+        {
+            auto bytes_for_block = BLOCK_BYTES - buffer_size;
+
+            // not enough data for whole block?
+            if (bytes_for_block > data.size())
+            {
+                std::memcpy(buffer_block + buffer_size, data.data(), data.size());
+                buffer_size += data.size();
+                CC_ASSERT(buffer_size < BLOCK_BYTES);
+                return;
+            }
+
+            // fill block
+            std::memcpy(buffer_block + buffer_size, data.data(), bytes_for_block);
+            data = data.subspan(bytes_for_block);
+            transform(buffer_block);
+            buffer_size = 0;
+        }
+    }
+
+    /*
+     * Add padding and return the message digest.
+     */
+    [[nodiscard]] cc::array<std::byte, 20> finalize()
+    {
+        /* Total number of hashed bits */
+        uint64_t total_bits = total_size_in_bytes * 8;
+
+        /* Padding */
+        // append the bit '1' to the message e.g. by adding 0x80 if message length is a multiple of 8 bits.
+        buffer_block[buffer_size++] = (std::byte)0x80;
+
+        // append 0 <= k < 512 bits '0', such that the resulting message length in bits is congruent to −64 === 448 (mod 512)
+        while (buffer_size % 64 != 56)
+            buffer_block[buffer_size++] = (std::byte)0x00;
+
+        // append ml, the original message length in bits, as a 64-bit big-endian integer.
+        // NOTE: could save 4 byteswaps by doing this in transform
+        *(uint64_t*)(buffer_block + buffer_size) = cc::byteswap(total_bits);
+        buffer_size += 8;
+        CC_ASSERT(buffer_size == BLOCK_BYTES || buffer_size == 2 * BLOCK_BYTES);
+
+        // update buffers
+        transform(buffer_block);
+        if (buffer_size == 2 * BLOCK_BYTES)
+            transform(buffer_block + BLOCK_BYTES);
+
+        // build result
+        digest[0] = cc::byteswap(digest[0]);
+        digest[1] = cc::byteswap(digest[1]);
+        digest[2] = cc::byteswap(digest[2]);
+        digest[3] = cc::byteswap(digest[3]);
+        digest[4] = cc::byteswap(digest[4]);
+        cc::array<std::byte, 20> res;
+        cc::as_byte_span(digest).copy_to(res);
+
+        return res;
+    }
+};
+}
+
+cc::array<std::byte, 20> cc::make_hash_sha1(cc::span<const std::byte> data)
+{
+    sha1_builder sha1;
+
+    sha1.reset();
+    sha1.update(data);
+    return sha1.finalize();
+}
+
+cc::array<std::byte, 20> cc::make_hash_sha1(string_view data) { return cc::make_hash_sha1(cc::as_byte_span(data)); }
+
+cc::string cc::make_hash_sha1_string(cc::span<const std::byte> data)
+{
+    auto hex = "0123456789abcdef";
+    auto hash = cc::make_hash_sha1(data);
+    auto s = cc::string::uninitialized(40);
+    for (auto i = 0; i < 20; ++i)
+    {
+        s[i * 2 + 0] = hex[uint8_t(hash[i]) >> 4];
+        s[i * 2 + 1] = hex[uint8_t(hash[i]) & 0b1111];
+    }
+    return s;
+}
+
+cc::string cc::make_hash_sha1_string(string_view data) { return cc::make_hash_sha1_string(cc::as_byte_span(data)); }

--- a/src/clean-core/hash.sha1.hh
+++ b/src/clean-core/hash.sha1.hh
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <clean-core/array.hh>
+#include <clean-core/span.hh>
+#include <clean-core/string.hh>
+
+// TODO: version where data can be streamed in
+
+namespace cc
+{
+// returns a hash of the data by executing SHA1
+cc::array<std::byte, 20> make_hash_sha1(cc::string_view data);
+cc::array<std::byte, 20> make_hash_sha1(cc::span<std::byte const> data);
+// same as make_hash_sha1, but the result is a hex string (length is 40)
+cc::string make_hash_sha1_string(cc::string_view data);
+cc::string make_hash_sha1_string(cc::span<std::byte const> data);
+}

--- a/src/clean-core/hash.xxh3.cc
+++ b/src/clean-core/hash.xxh3.cc
@@ -1,0 +1,5 @@
+#include "hash.xxh3.hh"
+
+#include <clean-core/detail/xxHash/xxh3.hh>
+
+uint64_t cc::make_hash_xxh3(cc::span<const std::byte> data, uint64_t seed) { return XXH3_64bits_withSeed(data.data(), data.size(), seed); }

--- a/src/clean-core/hash.xxh3.hh
+++ b/src/clean-core/hash.xxh3.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <clean-core/span.hh>
+
+namespace cc
+{
+// returns a hash of the data by executing https://github.com/Cyan4973/xxHash
+uint64_t make_hash_xxh3(cc::span<std::byte const> data, uint64_t seed);
+}

--- a/src/clean-core/intrinsics.hh
+++ b/src/clean-core/intrinsics.hh
@@ -105,6 +105,42 @@ CC_FORCE_INLINE int64_t intrin_atomic_add(int64_t volatile* counter, int64_t val
 #endif
 }
 
+CC_FORCE_INLINE uint8_t intrin_atomic_or(uint8_t volatile* counter, uint8_t value)
+{
+#ifdef CC_COMPILER_MSVC
+    return _InterlockedOr8((volatile char*)counter, value);
+#else
+    return __sync_fetch_and_or(counter, value);
+#endif
+}
+
+CC_FORCE_INLINE uint16_t intrin_atomic_or(uint16_t volatile* counter, uint16_t value)
+{
+#ifdef CC_COMPILER_MSVC
+    return _InterlockedOr16((volatile short*)counter, value);
+#else
+    return __sync_fetch_and_or(counter, value);
+#endif
+}
+
+CC_FORCE_INLINE uint32_t intrin_atomic_or(uint32_t volatile* counter, uint32_t value)
+{
+#ifdef CC_COMPILER_MSVC
+    return _InterlockedOr((volatile long*)counter, value);
+#else
+    return __sync_fetch_and_or(counter, value);
+#endif
+}
+
+CC_FORCE_INLINE uint64_t intrin_atomic_or(uint64_t volatile* counter, uint64_t value)
+{
+#ifdef CC_COMPILER_MSVC
+    return _InterlockedOr64((volatile long long*)counter, value);
+#else
+    return __sync_fetch_and_or(counter, value);
+#endif
+}
+
 template <class T>
 CC_FORCE_INLINE T* intrin_cas_pointer_t(T* volatile* destination, T* comparand, T* exchange)
 {

--- a/src/clean-core/intrinsics.hh
+++ b/src/clean-core/intrinsics.hh
@@ -87,6 +87,15 @@ CC_FORCE_INLINE void* intrin_atomic_swap_pointer(void* volatile* destination, vo
 #endif
 }
 
+CC_FORCE_INLINE int16_t intrin_atomic_add(int16_t volatile* counter, int16_t value)
+{
+#ifdef CC_COMPILER_MSVC
+    return _InterlockedExchangeAdd16((volatile short*)counter, value);
+#else
+    return __sync_fetch_and_add(counter, value);
+#endif
+}
+
 CC_FORCE_INLINE int32_t intrin_atomic_add(int32_t volatile* counter, int32_t value)
 {
 #ifdef CC_COMPILER_MSVC

--- a/src/clean-core/macros.hh
+++ b/src/clean-core/macros.hh
@@ -130,7 +130,7 @@
 #define CC_CONDITION_LIKELY(x) (x) [[msvc::likely]]
 #define CC_CONDITION_UNLIKELY(x) (x) [[msvc::unlikely]]
 #define CC_COLD_FUNC
-#define CC_HOT_FUNC __declspec(safebuffers, spectre(nomitigation))
+#define CC_HOT_FUNC
 
 #define CC_BUILTIN_UNREACHABLE __assume(0)
 #define CC_COUNTOF(arr) _countof(arr)

--- a/src/clean-core/macros.hh
+++ b/src/clean-core/macros.hh
@@ -45,6 +45,11 @@
 #endif
 #endif
 
+// from CMake:
+// CC_DEBUG is defined in debug configurations
+// CC_RELEASE in release configurations
+// CC_RELWITHDEBINFO in release-with-debug
+
 // =========
 // operating systems
 // CC_OS_WINDOWS, CC_OS_LINUX, CC_OS_APPLE, or CC_OS_BSD
@@ -159,6 +164,12 @@
 
 #else
 #error "Unknown compiler"
+#endif
+
+#ifdef CC_DEBUG
+#define CC_FORCE_INLINE_DEBUGGABLE inline
+#else
+#define CC_FORCE_INLINE_DEBUGGABLE CC_FORCE_INLINE
 #endif
 
 // =========

--- a/src/clean-core/macros.hh
+++ b/src/clean-core/macros.hh
@@ -135,6 +135,7 @@
 #define CC_BUILTIN_UNREACHABLE __assume(0)
 #define CC_COUNTOF(arr) _countof(arr)
 #define CC_ASSUME(x) __assume(x)
+#define CC_ANALYSIS_ASSUME(Condition) __analysis_assume(!!(Condition))
 
 #elif defined(CC_COMPILER_POSIX)
 
@@ -161,6 +162,7 @@
 #else
 #define CC_ASSUME(x) ((!x) ? __builtin_unreachable() : void(0))
 #endif
+#define CC_ANALYSIS_ASSUME(Condition) (void)0
 
 #else
 #error "Unknown compiler"

--- a/src/clean-core/macros.hh
+++ b/src/clean-core/macros.hh
@@ -133,7 +133,7 @@
 #define CC_HOT_FUNC
 
 #define CC_BUILTIN_UNREACHABLE __assume(0)
-#define CC_COUNTOF(arr) _countof(arr)
+#define CC_COUNTOF(arr) __crt_countof(arr)
 #define CC_ASSUME(x) __assume(x)
 
 #elif defined(CC_COMPILER_POSIX)

--- a/src/clean-core/macros.hh
+++ b/src/clean-core/macros.hh
@@ -135,7 +135,6 @@
 #define CC_BUILTIN_UNREACHABLE __assume(0)
 #define CC_COUNTOF(arr) _countof(arr)
 #define CC_ASSUME(x) __assume(x)
-#define CC_ANALYSIS_ASSUME(Condition) __analysis_assume(!!(Condition))
 
 #elif defined(CC_COMPILER_POSIX)
 
@@ -162,7 +161,6 @@
 #else
 #define CC_ASSUME(x) ((!x) ? __builtin_unreachable() : void(0))
 #endif
-#define CC_ANALYSIS_ASSUME(Condition) (void)0
 
 #else
 #error "Unknown compiler"

--- a/src/clean-core/move.hh
+++ b/src/clean-core/move.hh
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <clean-core/detail/remove_reference.hh>
+#include <clean-core/macros.hh>
 
 namespace cc
 {
 template <class T>
-constexpr remove_reference<T>&& move(T&& t) noexcept
+CC_FORCE_INLINE constexpr remove_reference<T>&& move(T&& t) noexcept
 {
     return static_cast<remove_reference<T>&&>(t);
 }

--- a/src/clean-core/native/memory.cc
+++ b/src/clean-core/native/memory.cc
@@ -75,7 +75,11 @@ void cc::commit_physical_memory(std::byte* ptr, size_t size)
 
 #elif defined(CC_OS_LINUX)
 
-    int const res = ::mprotect(ptr, size, PROT_READ | PROT_WRITE);
+    // ensure ptr and size are page-aligned
+    auto new_ptr = cc::align_down(ptr, 4096);
+    auto new_size = cc::align_up(size + (ptr - new_ptr), 4096);
+
+    int const res = ::mprotect(new_ptr, new_size, PROT_READ | PROT_WRITE);
     CC_ASSERT(res == 0 && "virtual commit failed");
 
 #else
@@ -92,8 +96,12 @@ void cc::decommit_physical_memory(std::byte* ptr, size_t size)
 
 #elif defined(CC_OS_LINUX)
 
+    // ensure ptr and size are page-aligned
+    auto new_ptr = cc::align_down(ptr, 4096);
+    auto new_size = cc::align_up(size + (ptr - new_ptr), 4096);
+
     // TODO: not sure if this actually decommits memory
-    int const res = ::mprotect(ptr, size, PROT_NONE);
+    int const res = ::mprotect(new_ptr, new_size, PROT_NONE);
     CC_ASSERT(res == 0 && "virtual decommit failed");
 
 #else

--- a/src/clean-core/native/memory.hh
+++ b/src/clean-core/native/memory.hh
@@ -17,6 +17,9 @@ void free_virtual_memory(std::byte* ptr, size_t size_bytes);
 // commits a region of pages inside a reserved, virtual memory range
 void commit_physical_memory(std::byte* ptr, size_t size_bytes);
 
+// touches (reads) the first byte of every page in this range to ensure pages are available
+void prefault_memory(std::byte* ptr, size_t size_bytes);
+
 // decommits a region of pages inside a reserved, virtual memory range
 void decommit_physical_memory(std::byte* ptr, size_t size_bytes);
 

--- a/src/clean-core/print.cc
+++ b/src/clean-core/print.cc
@@ -3,9 +3,21 @@
 #include <clean-core/temp_cstr.hh>
 
 void cc::print(string_view s) { ::fputs(cc::temp_cstr(s), stdout); }
+void cc::print(char const* s) { ::fputs(s, stdout); }
+void cc::print(cc::string const& s) { ::fputs(s.c_str(), stdout); }
 
 void cc::println(string_view s)
 {
     ::puts(cc::temp_cstr(s));
+    ::fflush(stdout);
+}
+void cc::println(char const* s)
+{
+    ::puts(s);
+    ::fflush(stdout);
+}
+void cc::println(cc::string const& s)
+{
+    ::puts(s.c_str());
     ::fflush(stdout);
 }

--- a/src/clean-core/print.cc
+++ b/src/clean-core/print.cc
@@ -1,0 +1,11 @@
+#include "print.hh"
+
+#include <clean-core/temp_cstr.hh>
+
+void cc::print(string_view s) { ::fputs(cc::temp_cstr(s), stdout); }
+
+void cc::println(string_view s)
+{
+    ::puts(cc::temp_cstr(s));
+    ::fflush(stdout);
+}

--- a/src/clean-core/print.hh
+++ b/src/clean-core/print.hh
@@ -12,7 +12,14 @@ void print(char const* fmt_str, Args const&... args)
 {
     ::fputs(cc::format(fmt_str, args...).c_str(), stdout);
 }
+void print(char const* s);
 void print(cc::string_view s);
+void print(cc::string const& s);
+template <class T>
+void print(T const& v)
+{
+    cc::print("%s", v);
+}
 /// prints the given formatted string to stdout and appends a \n
 /// NOTE: also flushes the stream
 ///       if this behavior is not desired, use cc::print with \n as part of the format string
@@ -22,5 +29,12 @@ void println(char const* fmt_str, Args const&... args)
     ::puts(cc::format(fmt_str, args...).c_str());
     ::fflush(stdout);
 }
+void println(char const* s);
 void println(cc::string_view s);
+void println(cc::string const& s);
+template <class T>
+void println(T const& v)
+{
+    cc::println("%s", v);
+}
 }

--- a/src/clean-core/print.hh
+++ b/src/clean-core/print.hh
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdio>
+
+#include <clean-core/format.hh>
+
+namespace cc
+{
+/// prints the given formatted string to stdout
+template <class Formatter = detail::default_formatter, class... Args>
+void print(char const* fmt_str, Args const&... args)
+{
+    ::fputs(cc::format(fmt_str, args...).c_str(), stdout);
+}
+void print(cc::string_view s);
+/// prints the given formatted string to stdout and appends a \n
+/// NOTE: also flushes the stream
+///       if this behavior is not desired, use cc::print with \n as part of the format string
+template <class Formatter = detail::default_formatter, class... Args>
+void println(char const* fmt_str, Args const&... args)
+{
+    ::puts(cc::format(fmt_str, args...).c_str());
+    ::fflush(stdout);
+}
+void println(cc::string_view s);
+}

--- a/src/clean-core/sbo_string.hh
+++ b/src/clean-core/sbo_string.hh
@@ -81,6 +81,10 @@ public:
         _data = _sbo;
     }
 
+    // make sure ints and bools are not implicitly convertible
+    sbo_string(int) = delete;
+    sbo_string(bool) = delete;
+
     sbo_string(char const* s)
     {
         _size = std::strlen(s);

--- a/src/clean-core/shared_ptr.hh
+++ b/src/clean-core/shared_ptr.hh
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#include <clean-core/allocate.hh>
+#include <clean-core/assert.hh>
+#include <clean-core/forward.hh>
+#include <clean-core/fwd.hh>
+
+namespace cc
+{
+template <class T, class... Args>
+shared_ptr<T> make_shared(Args&&... args);
+
+/// a high-performance, basic ref-counted pointer
+/// in particular:
+///  - no thread-safety (no atomic access required)
+///  - no weak_ptr (simplifies control block)
+///  - only make_shared supported (less code, less indirection)
+///  - no custom allocation / deleter (allows cc::alloc / cc::free)
+template <class T>
+struct shared_ptr
+{
+    static_assert(!std::is_reference_v<T>, "cannot created a shared_ptr of a reference");
+
+    bool is_valid() const { return _control != nullptr; }
+    operator bool() const { return is_valid(); }
+
+    T& operator*() const
+    {
+        CC_ASSERT(is_valid());
+        return _control->value;
+    }
+
+    T* operator->() const
+    {
+        CC_ASSERT(is_valid());
+        return &_control->value;
+    }
+
+    uint32_t refcount() const { return _control ? _control->refcount : 0; }
+
+    void reset()
+    {
+        if (_control)
+        {
+            dec_refcount();
+            _control = nullptr;
+        }
+    }
+
+    shared_ptr() = default;
+    shared_ptr(shared_ptr&& rhs) noexcept
+    {
+        _control = rhs._control;
+        rhs._control = nullptr;
+    }
+    shared_ptr(shared_ptr const& rhs)
+    {
+        _control = rhs._control;
+        _control->refcount++;
+    }
+    shared_ptr& operator=(shared_ptr&& rhs) noexcept
+    {
+        if (_control)
+            dec_refcount(); // might set rhs._control to 0
+
+        _control = rhs._control;
+        rhs._control = nullptr;
+
+        return *this;
+    }
+    shared_ptr& operator=(shared_ptr const& rhs)
+    {
+        if (this == &rhs)
+            return *this;
+
+        if (_control)
+            dec_refcount();
+
+        _control = rhs._control;
+        _control->refcount++;
+
+        return *this;
+    }
+    ~shared_ptr()
+    {
+        if (_control)
+            dec_refcount();
+    }
+
+private:
+    void dec_refcount()
+    {
+        if (--_control->refcount == 0)
+        {
+            cc::free(_control);
+            _control = nullptr;
+        }
+    }
+
+    struct control
+    {
+        T value;
+        uint32_t refcount;
+
+        template <class... Args>
+        control(Args&&... args) : value(cc::forward<Args>(args)...), refcount(1)
+        {
+        }
+    };
+
+    control* _control = nullptr;
+
+    template <class T, class... Args>
+    friend shared_ptr<T> make_shared(Args&&... args);
+};
+
+template <class T, class... Args>
+shared_ptr<T> make_shared(Args&&... args)
+{
+    shared_ptr<T> s;
+    s._control = cc::alloc<shared_ptr<T>::control>(cc::forward<Args>(args)...);
+    return s;
+}
+}

--- a/src/clean-core/shared_ptr.hh
+++ b/src/clean-core/shared_ptr.hh
@@ -7,6 +7,7 @@
 #include <clean-core/assert.hh>
 #include <clean-core/forward.hh>
 #include <clean-core/fwd.hh>
+#include <clean-core/macros.hh>
 
 namespace cc
 {
@@ -114,8 +115,11 @@ private:
 
     struct control
     {
-        T value; // must stay first arg, so that _control == &_control->value
-        uint32_t refcount;
+        // must stay first arg, so that _control == &_control->value
+        T value;
+
+        // int -> make overflow UB
+        int refcount;
 
         template <class... Args>
         control(Args&&... args) : value(cc::forward<Args>(args)...), refcount(1)

--- a/src/clean-core/shared_ptr.hh
+++ b/src/clean-core/shared_ptr.hh
@@ -19,6 +19,7 @@ shared_ptr<T> make_shared(Args&&... args);
 ///  - no weak_ptr (simplifies control block)
 ///  - only make_shared supported (less code, less indirection)
 ///  - no custom allocation / deleter (allows cc::alloc / cc::free)
+///  - no shared_from_this (consequence of no-weak-ptr)
 template <class T>
 struct shared_ptr
 {
@@ -38,6 +39,8 @@ struct shared_ptr
         CC_ASSERT(is_valid());
         return &_control->value;
     }
+
+    bool is_unique() const { return refcount() == 1; }
 
     uint32_t refcount() const { return _control ? _control->refcount : 0; }
 

--- a/src/clean-core/string_view.hh
+++ b/src/clean-core/string_view.hh
@@ -39,6 +39,11 @@ struct equals_case_insensitive_t
 struct string_view
 {
     constexpr string_view() = default;
+
+    // make sure int and bool are not convertible
+    string_view(int) = delete;
+    string_view(bool) = delete;
+
     constexpr string_view(char const* data)
     {
         _data = data;

--- a/src/clean-core/to_string.cc
+++ b/src/clean-core/to_string.cc
@@ -376,7 +376,8 @@ parsed_fmt_args parse_args(cc::string_view fmt_args)
     auto const is_align = [](char c) { return c == '<' || c == '>' || c == '^'; };
     auto const is_sign = [](char c) { return c == '+' || c == '-' || c == ' '; };
 
-    auto const parse_unsigned_int = [&](char const* begin, char const* end, int& out) -> char const* {
+    auto const parse_unsigned_int = [&](char const* begin, char const* end, int& out) -> char const*
+    {
         out = *begin - '0';
         ++begin;
         while (begin != end && cc::is_digit(*begin))
@@ -473,14 +474,16 @@ char const* unsigned_int_to_binary(IntType value, char* end)
 template <class IntType>
 void unsigned_to_string_impl(cc::string_stream_ref ss, IntType value, parsed_fmt_args const& args)
 {
-    auto const add_fill = [&](int length) {
+    auto const add_fill = [&](int length)
+    {
         auto const fill = args.sign_aware_zero_padding ? '0' : args.fill;
         if (args.width > 0 && length < args.width)
             for (auto i = 0; i < args.width - length; ++i)
                 ss << fill;
     };
 
-    auto const to_binary = [&]() {
+    auto const to_binary = [&]()
+    {
         char buffer[sizeof(IntType) * 8 + 1];
         char* end = buffer + sizeof(buffer);
         char const* begin = unsigned_int_to_binary(value, end);
@@ -492,6 +495,7 @@ void unsigned_to_string_impl(cc::string_stream_ref ss, IntType value, parsed_fmt
     {
     case 0:   // fallthrough
     case 'd': // default, decimal
+    case 'u':
     {
         char buffer[20 + 1]; // large enough to hold uint64_t decimals
         auto const length = std::snprintf(buffer, sizeof(buffer), args.sign_aware_zero_padding ? "%0llu" : "%llu", static_cast<unsigned long long>(value));

--- a/src/clean-core/variant.hh
+++ b/src/clean-core/variant.hh
@@ -8,14 +8,21 @@
 #include <clean-core/forward.hh>
 #include <clean-core/fwd.hh>
 #include <clean-core/has_operator.hh>
+#include <clean-core/move.hh>
 #include <clean-core/new.hh>
 
 namespace cc
 {
 namespace detail
 {
+template <class... Types>
+struct first_of;
+
 template <class T, class... Types>
-using first_of = T;
+struct first_of<T, Types...>
+{
+    using type = T;
+};
 
 template <class T, class... Types>
 static constexpr bool is_equal_any_of = (std::is_same_v<T, Types> || ...);
@@ -24,7 +31,7 @@ template <class T, class... Types>
 constexpr int index_of_type()
 {
     int i = -1;
-    ((++i, std::is_same_v<T, Types>) || ...);
+    (void)((++i, std::is_same_v<T, Types>) || ...);
     return i == int(sizeof...(Types)) ? -1 : i;
 }
 
@@ -124,7 +131,7 @@ struct variant
 
     variant()
     {
-        using T = detail::first_of<Types...>;
+        using T = typename detail::first_of<Types...>::type;
         static_assert(std::is_default_constructible_v<T>, "first type of variant is not default constructible");
         _data.template emplace<T>();
     }

--- a/src/clean-core/variant.hh
+++ b/src/clean-core/variant.hh
@@ -171,14 +171,12 @@ struct variant
     {
         constexpr auto i = detail::index_of_type<T, Types...>();
         static_assert(i >= 0, "cannot construct variant from this type. NOTE: implicit conversions are not allowed");
-        _data.destroy(_idx);
         _idx = uint8_t(i);
-        _data.template emplace<std::decay_t<T>>(cc::forward<T>(v));
+        this->emplace<std::decay_t<T>>(cc::forward<T>(v));
         return *this;
     }
     variant& operator=(variant&& rhs) noexcept
     {
-        _data.destroy(_idx);
         return rhs.visit(
             [&](auto&& v) -> variant&
             {
@@ -189,7 +187,6 @@ struct variant
     }
     variant& operator=(variant const& rhs)
     {
-        _data.destroy(_idx);
         return rhs.visit(
             [&](auto const& v) -> variant&
             {

--- a/src/clean-core/variant.hh
+++ b/src/clean-core/variant.hh
@@ -178,7 +178,6 @@ struct variant
     {
         constexpr auto i = detail::index_of_type<T, Types...>();
         static_assert(i >= 0, "cannot construct variant from this type. NOTE: implicit conversions are not allowed");
-        _idx = uint8_t(i);
         this->emplace<std::decay_t<T>>(cc::forward<T>(v));
         return *this;
     }

--- a/src/clean-core/variant.hh
+++ b/src/clean-core/variant.hh
@@ -139,11 +139,12 @@ struct variant
     }
     variant(variant&& rhs) noexcept
     {
-        static_assert(std::is_move_constructible_v<Types> && ..., "all types must be movable");
+        static_assert((std::is_move_constructible_v<Types> && ...), "all types must be movable");
         // TODO: maybe better comp time if co-recurse
         rhs.visit(
             [&](auto& v)
             {
+                using T = std::decay_t<decltype(v)>;
                 constexpr auto i = detail::index_of_type<T, Types...>();
                 static_assert(i >= 0, "cannot construct variant from this type. NOTE: implicit conversions are not allowed");
                 _idx = uint8_t(i);
@@ -152,11 +153,12 @@ struct variant
     }
     variant(variant const& rhs)
     {
-        static_assert(std::is_copy_constructible_v<Types> && ..., "all types must be copyable");
+        static_assert((std::is_copy_constructible_v<Types> && ...), "all types must be copyable");
         // TODO: maybe better comp time if co-recurse
         rhs.visit(
             [&](auto const& v)
             {
+                using T = std::decay_t<decltype(v)>;
                 constexpr auto i = detail::index_of_type<T, Types...>();
                 static_assert(i >= 0, "cannot construct variant from this type. NOTE: implicit conversions are not allowed");
                 _idx = uint8_t(i);

--- a/src/clean-core/variant.hh
+++ b/src/clean-core/variant.hh
@@ -1,0 +1,292 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#include <clean-core/assert.hh>
+#include <clean-core/enable_if.hh>
+#include <clean-core/forward.hh>
+#include <clean-core/fwd.hh>
+#include <clean-core/has_operator.hh>
+#include <clean-core/new.hh>
+
+namespace cc
+{
+namespace detail
+{
+template <class T, class... Types>
+using first_of = T;
+
+template <class T, class... Types>
+static constexpr bool is_equal_any_of = (std::is_same_v<T, Types> || ...);
+
+template <class T, class... Types>
+constexpr int index_of_type()
+{
+    int i = -1;
+    ((++i, std::is_same_v<T, Types>) || ...);
+    return i == int(sizeof...(Types)) ? -1 : i;
+}
+
+template <class... Types>
+struct variant_impl;
+template <>
+struct variant_impl<>
+{
+};
+template <class T, class... Rest>
+struct variant_impl<T, Rest...>
+{
+    static_assert(!std::is_reference_v<T>, "cannot create a variance of references");
+    static_assert(!std::is_array_v<T>, "cannot create a variance of array type");
+
+    union data
+    {
+        T head;
+        variant_impl<Rest...> tail;
+
+        data() {}
+        ~data() {}
+    } _data;
+
+    // NOTE: must be destroyed before
+    template <class U, class... Args>
+    U& emplace(Args&&... args)
+    {
+        if constexpr (std::is_same_v<T, U>)
+            return *new (cc::placement_new, &_data.head) T(cc::forward<Args>(args)...);
+        else
+        {
+            static_assert(sizeof...(Rest) > 0, "could not find type in variant");
+            return _data.tail.template emplace<U>(cc::forward<Args>(args)...);
+        }
+    }
+
+    template <class U>
+    U& get()
+    {
+        if constexpr (std::is_same_v<T, U>)
+            return _data.head;
+        else
+        {
+            static_assert(sizeof...(Rest) > 0, "could not find type in variant");
+            return _data.tail.template get<U>();
+        }
+    }
+
+    template <class U>
+    U const& get() const
+    {
+        if constexpr (std::is_same_v<T, U>)
+            return _data.head;
+        else
+        {
+            static_assert(sizeof...(Rest) > 0, "could not find type in variant");
+            return _data.tail.template get<U>();
+        }
+    }
+
+    void destroy(uint8_t idx)
+    {
+        if (idx == 0)
+            _data.head.~T();
+        else if constexpr (sizeof...(Rest) > 0)
+            _data.tail.destroy(idx - 1);
+    }
+
+    template <class F>
+    decltype(auto) visit(uint8_t idx, F&& f)
+    {
+        if constexpr (sizeof...(Rest) > 0)
+            if (idx > 0)
+                return _data.tail.visit(idx - 1, f);
+
+        return f(_data.head);
+    }
+    template <class F>
+    decltype(auto) visit(uint8_t idx, F&& f) const
+    {
+        if constexpr (sizeof...(Rest) > 0)
+            if (idx > 0)
+                return _data.tail.visit(idx - 1, f);
+
+        return f(_data.head);
+    }
+};
+}
+
+// TODO: inherit triviality
+// NOTE: currently only supports exact type matches
+template <class... Types>
+struct variant
+{
+    static_assert(sizeof...(Types) >= 1, "variant must have at least one type");
+
+    variant()
+    {
+        using T = detail::first_of<Types...>;
+        static_assert(std::is_default_constructible_v<T>, "first type of variant is not default constructible");
+        _data.template emplace<T>();
+    }
+
+    template <class T, cc::enable_if<!std::is_same_v<T, variant>> = true>
+    variant(T&& v) noexcept(noexcept(T(v)))
+    {
+        constexpr auto i = detail::index_of_type<T, Types...>();
+        static_assert(i >= 0, "cannot construct variant from this type. NOTE: implicit conversions are not allowed");
+        _idx = uint8_t(i);
+        _data.template emplace<T>(cc::forward<T>(v));
+    }
+    variant(variant&& rhs) noexcept
+    {
+        static_assert(std::is_move_constructible_v<Types> && ..., "all types must be movable");
+        // TODO: maybe better comp time if co-recurse
+        rhs.visit(
+            [&](auto& v)
+            {
+                constexpr auto i = detail::index_of_type<T, Types...>();
+                static_assert(i >= 0, "cannot construct variant from this type. NOTE: implicit conversions are not allowed");
+                _idx = uint8_t(i);
+                _data.template emplace<T>(cc::move(v));
+            });
+    }
+    variant(variant const& rhs)
+    {
+        static_assert(std::is_copy_constructible_v<Types> && ..., "all types must be copyable");
+        // TODO: maybe better comp time if co-recurse
+        rhs.visit(
+            [&](auto const& v)
+            {
+                constexpr auto i = detail::index_of_type<T, Types...>();
+                static_assert(i >= 0, "cannot construct variant from this type. NOTE: implicit conversions are not allowed");
+                _idx = uint8_t(i);
+                _data.template emplace<T>(v);
+            });
+    }
+
+    template <class T, cc::enable_if<!std::is_same_v<T, variant>> = true>
+    variant& operator=(T&& v) noexcept(noexcept(T(v)))
+    {
+        constexpr auto i = detail::index_of_type<T, Types...>();
+        static_assert(i >= 0, "cannot construct variant from this type. NOTE: implicit conversions are not allowed");
+        _data.destroy(_idx);
+        _idx = uint8_t(i);
+        _data.template emplace<T>(cc::forward<T>(v));
+        return *this;
+    }
+    variant& operator=(variant&& rhs) noexcept
+    {
+        rhs.visit([&](auto&& v) { return *this = cc::forward<decltype(v)>(v); });
+    }
+    variant& operator=(variant const& rhs)
+    {
+        rhs.visit([&](auto&& v) { return *this = cc::forward<decltype(v)>(v); });
+    }
+
+    ~variant() { _data.destroy(_idx); }
+
+    template <class T, class... Args>
+    T& emplace(Args&&... args)
+    {
+        _data.destroy(_idx);
+        constexpr auto i = detail::index_of_type<T, Types...>();
+        static_assert(i >= 0, "cannot construct variant from this type. NOTE: implicit conversions are not allowed");
+        _idx = uint8_t(i);
+        return _data.template emplace<T>(cc::forward<Args>(args)...);
+    }
+
+    template <class F>
+    decltype(auto) visit(F&& f)
+    {
+        return _data.visit(_idx, f);
+    }
+    template <class F>
+    decltype(auto) visit(F&& f) const
+    {
+        return _data.visit(_idx, f);
+    }
+
+    /// replace this.value with f(this.value)
+    /// can change the currently held type
+    /// cannot add new types
+    template <class F>
+    void transform(F&& f)
+    {
+        _data.visit([&](auto&& v) { *this = f(v); });
+    }
+
+    template <class T>
+    bool is() const
+    {
+        return int(_idx) == detail::index_of_type<T, Types...>();
+    }
+
+    template <class T>
+    T& get()
+    {
+        CC_ASSERT(this->is<T>());
+        static_assert(detail::is_equal_any_of<T, Types...>, "variant does not have this type");
+        return _data.template get<T>();
+    }
+    template <class T>
+    T const& get() const
+    {
+        CC_ASSERT(this->is<T>());
+        static_assert(detail::is_equal_any_of<T, Types...>, "variant does not have this type");
+        return _data.template get<T>();
+    }
+
+private:
+    uint8_t _idx = 0;
+    detail::variant_impl<Types...> _data;
+};
+
+template <class T, class... Types>
+bool operator==(T const& lhs, variant<Types...> const& rhs)
+{
+    return rhs.visit(
+        [&lhs](auto const& rhs)
+        {
+            if constexpr (cc::has_operator_equal<T, decltype(rhs)>)
+                return lhs == rhs;
+            else
+                return false;
+        });
+}
+template <class T, class... Types>
+bool operator!=(T const& lhs, variant<Types...> const& rhs)
+{
+    return rhs.visit(
+        [&lhs](auto const& rhs)
+        {
+            if constexpr (cc::has_operator_not_equal<T, decltype(rhs)>)
+                return lhs != rhs;
+            else
+                return true;
+        });
+}
+template <class T, class... Types>
+bool operator==(variant<Types...> const& lhs, T const& rhs)
+{
+    return lhs.visit(
+        [&rhs](auto const& lhs)
+        {
+            if constexpr (cc::has_operator_equal<decltype(lhs), T>)
+                return lhs == rhs;
+            else
+                return false;
+        });
+}
+template <class T, class... Types>
+bool operator!=(variant<Types...> const& lhs, T const& rhs)
+{
+    return lhs.visit(
+        [&rhs](auto const& lhs)
+        {
+            if constexpr (cc::has_operator_not_equal<decltype(lhs), T>)
+                return lhs != rhs;
+            else
+                return true;
+        });
+}
+}

--- a/src/clean-core/variant.hh
+++ b/src/clean-core/variant.hh
@@ -130,7 +130,7 @@ struct variant
     }
 
     template <class T, cc::enable_if<!std::is_same_v<T, variant>> = true>
-    variant(T&& v) noexcept(noexcept(T(v)))
+    variant(T&& v) noexcept(noexcept(T(cc::forward<T>(v))))
     {
         constexpr auto i = detail::index_of_type<T, Types...>();
         static_assert(i >= 0, "cannot construct variant from this type. NOTE: implicit conversions are not allowed");

--- a/src/clean-core/variant.hh
+++ b/src/clean-core/variant.hh
@@ -249,6 +249,12 @@ struct variant
         return _data.template get<T>();
     }
 
+    template <class T>
+    T const& get_or(T const& default_val) const
+    {
+        return this->is<T>() ? this->get<T>() : default_val;
+    }
+
 private:
     uint8_t _idx = 0;
     detail::variant_impl<Types...> _data;

--- a/src/clean-core/vector.hh
+++ b/src/clean-core/vector.hh
@@ -9,6 +9,8 @@ namespace cc
 template <class T>
 struct vector : detail::vector_base<T, size_t, false>
 {
+    static_assert(!std::is_const_v<T>, "vector of const objects is not allowed");
+
     // ctors
 public:
     vector() = default;

--- a/src/clean-core/vector.hh
+++ b/src/clean-core/vector.hh
@@ -20,8 +20,11 @@ public:
         detail::container_default_construct_or_zeroed(size, this->_data);
     }
 
+    /// returns a vector with "size" elements that are default-initialized
     [[nodiscard]] static vector defaulted(size_t size) { return vector(size); }
 
+    /// returns a vector with "size" elements that are uninitialized
+    /// CAUTION: for non-pod types, you have to know what you're doing (i.e. placement new yourself)
     [[nodiscard]] static vector uninitialized(size_t size)
     {
         vector v;
@@ -31,10 +34,19 @@ public:
         return v;
     }
 
+    /// returns a vector with "size" elements all initialized with "value"
     [[nodiscard]] static vector filled(size_t size, T const& value)
     {
         vector v;
         v.resize(size, value);
+        return v;
+    }
+
+    /// returns a vector with "size" elements reserved, but size is actually 0
+    [[nodiscard]] static vector reserved(size_t size)
+    {
+        vector v;
+        v.reserve(size);
         return v;
     }
 

--- a/src/clean-core/xxHash.cc
+++ b/src/clean-core/xxHash.cc
@@ -1,5 +1,0 @@
-#include "xxHash.hh"
-
-#include <clean-core/detail/xxHash/xxh3.hh>
-
-uint64_t cc::hash_xxh3(cc::span<const std::byte> data, uint64_t seed) { return XXH3_64bits_withSeed(data.data(), data.size(), seed); }

--- a/src/clean-core/xxHash.hh
+++ b/src/clean-core/xxHash.hh
@@ -1,12 +1,15 @@
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
+// NOTE: this header will be removed in a future version
 
-#include <clean-core/span.hh>
+#include <clean-core/hash.xxh3.hh>
 
 namespace cc
 {
-// returns a hash of the data by executing https://github.com/Cyan4973/xxHash
-uint64_t hash_xxh3(cc::span<std::byte const> data, uint64_t seed);
+[[deprecated("use cc::make_hash_xxh3 directly. this header will be removed in the future. the new name is <clean-core/hash.xxh3.hh> "
+             "(2023-01-14)")]] inline uint64_t
+hash_xxh3(cc::span<std::byte const> data, uint64_t seed)
+{
+    return cc::make_hash_xxh3(data, seed);
+}
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,8 +9,16 @@ add_arcana_test(tests-clean-core "${SOURCES}")
 
 target_link_libraries(tests-clean-core PUBLIC
     clean-core
-    clean-ranges
     typed-geometry
     rich-log
-    ctracer
 )
+
+if (TARGET clean-ranges)
+	target_link_libraries(tests-clean-core PUBLIC clean-ranges)
+	target_compile_definitions(tests-clean-core PUBLIC HAS_CLEAN_RANGES)
+endif()
+
+if (TARGET ctracer)
+	target_link_libraries(tests-clean-core PUBLIC ctracer)
+	target_compile_definitions(tests-clean-core PUBLIC HAS_CTRACER)
+endif()

--- a/tests/alloc-benchmark.cc
+++ b/tests/alloc-benchmark.cc
@@ -1,3 +1,5 @@
+#if HAS_CTRACER
+
 #include <nexus/test.hh>
 
 #include <iostream>
@@ -178,3 +180,5 @@ TEST("cc::alloc benchmark")
         }
     });
 }
+
+#endif

--- a/tests/chunked_buffer.cc
+++ b/tests/chunked_buffer.cc
@@ -1,9 +1,42 @@
 #include <nexus/monte_carlo_test.hh>
 
+#include <clean-ranges/algorithms.hh>
+
 #include <clean-core/experimental/chunked_buffer.hh>
 #include <clean-core/vector.hh>
 
-MONTE_CARLO_TEST("cc::chunked_buffer")
+TEST("cc::chunked_buffer basics")
+{
+    cc::chunked_buffer<int> b;
+    b.set_chunk_size(100);
+
+    CHECK(b.size() == 0);
+    CHECK(cr::count(b.chunks()) == 0);
+
+    for ([[maybe_unused]] auto c : b.chunks())
+        CHECK(false); // should not be capped
+
+    b.push_back(1);
+    CHECK(b.size() == 1);
+    CHECK(cr::count(b.chunks()) == 1);
+    for (auto c : b.chunks())
+        CHECK(c.size() == 1);
+
+    for (auto i = 0; i < 10; ++i)
+        b.push_back(i);
+    CHECK(b.size() == 11);
+    CHECK(cr::count(b.chunks()) == 1);
+    for (auto c : b.chunks())
+        CHECK(c.size() == 11);
+
+    for (auto i = 0; i < 100; ++i)
+        b.push_back(i);
+    CHECK(b.size() == 111);
+    CHECK(cr::count(b.chunks()) == 2);
+    CHECK(cr::to<cc::vector>(b.chunks(), [](auto c) { return c.size(); }) == nx::range<size_t>{100, 11});
+}
+
+MONTE_CARLO_TEST("cc::chunked_buffer mct")
 {
     addOp("gen", [](tg::rng& rng) { return uniform(rng, -10, 10) * 2; });
 
@@ -30,7 +63,14 @@ MONTE_CARLO_TEST("cc::chunked_buffer")
         [](cc::vector<int> const& a, cc::chunked_buffer<int> const& b)
         {
             cc::vector<int> rhs;
+            cc::vector<int> rhs2;
+
             b.for_each_chunk([&](auto chunk) { rhs.push_back_range(chunk); });
+
+            for (auto c : b.chunks())
+                rhs2.push_back_range(c);
+
             REQUIRE(a == rhs);
+            REQUIRE(a == rhs2);
         });
 }

--- a/tests/chunked_buffer.cc
+++ b/tests/chunked_buffer.cc
@@ -1,10 +1,13 @@
 #include <nexus/monte_carlo_test.hh>
 
+#if HAS_CLEAN_RANGES
 #include <clean-ranges/algorithms.hh>
+#endif
 
 #include <clean-core/experimental/chunked_buffer.hh>
 #include <clean-core/vector.hh>
 
+#if HAS_CLEAN_RANGES
 TEST("cc::chunked_buffer basics")
 {
     cc::chunked_buffer<int> b;
@@ -35,6 +38,7 @@ TEST("cc::chunked_buffer basics")
     CHECK(cr::count(b.chunks()) == 2);
     CHECK(cr::to<cc::vector>(b.chunks(), [](auto c) { return c.size(); }) == nx::range<size_t>{100, 11});
 }
+#endif
 
 MONTE_CARLO_TEST("cc::chunked_buffer mct")
 {

--- a/tests/chunked_buffer.cc
+++ b/tests/chunked_buffer.cc
@@ -1,0 +1,36 @@
+#include <nexus/monte_carlo_test.hh>
+
+#include <clean-core/experimental/chunked_buffer.hh>
+#include <clean-core/vector.hh>
+
+MONTE_CARLO_TEST("cc::chunked_buffer")
+{
+    addOp("gen", [](tg::rng& rng) { return uniform(rng, -10, 10) * 2; });
+
+    addOp("ctor", [] { return cc::chunked_buffer<int>(); });
+    addOp("ctor", [] { return cc::vector<int>(); });
+    addOp("size", [](cc::chunked_buffer<int> const& buffer) { return buffer.size(); });
+    addOp("size", [](cc::vector<int> const& buffer) { return buffer.size(); });
+    addOp("push_back", [](cc::chunked_buffer<int>& buffer, int v) { buffer.push_back(v); });
+    addOp("push_back", [](cc::vector<int>& buffer, int v) { buffer.push_back(v); });
+    addOp("push_back_many",
+          [](cc::chunked_buffer<int>& buffer, int v)
+          {
+              for (auto i = 0; i < 2345; ++i)
+                  buffer.push_back(v + i);
+          });
+    addOp("push_back_many",
+          [](cc::vector<int>& buffer, int v)
+          {
+              for (auto i = 0; i < 2345; ++i)
+                  buffer.push_back(v + i);
+          });
+
+    testEquivalence(
+        [](cc::vector<int> const& a, cc::chunked_buffer<int> const& b)
+        {
+            cc::vector<int> rhs;
+            b.for_each_chunk([&](auto chunk) { rhs.push_back_range(chunk); });
+            REQUIRE(a == rhs);
+        });
+}

--- a/tests/hash-comparison.cc
+++ b/tests/hash-comparison.cc
@@ -1,5 +1,6 @@
 #include <nexus/app.hh>
 
+#undef RICH_LOG_FORCE_MACRO_PREFIX
 #include <rich-log/log.hh>
 
 #include <iostream>

--- a/tests/hash-comparison.cc
+++ b/tests/hash-comparison.cc
@@ -49,7 +49,7 @@ template <class... Args>
 size_t hash_combine_xxHash(Args... h)
 {
     size_t data[] = {h...};
-    return cc::hash_xxh3(cc::as_byte_span(data), 0xDEADBEEF);
+    return cc::make_hash_xxh3(cc::as_byte_span(data), 0xDEADBEEF);
 }
 }
 

--- a/tests/hash.sha1.cc
+++ b/tests/hash.sha1.cc
@@ -1,0 +1,385 @@
+#include <nexus/app.hh>
+#include <nexus/fuzz_test.hh>
+#include <nexus/test.hh>
+
+#include <ctracer/trace.hh>
+
+#include <rich-log/log.hh>
+
+#include <clean-core/indices_of.hh>
+
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <clean-core/hash.sha1.hh>
+
+namespace vog
+{
+namespace
+{
+
+
+class SHA1
+{
+public:
+    SHA1();
+    void update(const std::string& s);
+    void update(std::istream& is);
+    std::string final();
+    static std::string from_file(const std::string& filename);
+
+private:
+    uint32_t digest[5];
+    std::string buffer;
+    uint64_t transforms;
+};
+
+
+static const size_t BLOCK_INTS = 16; /* number of 32bit integers per SHA1 block */
+static const size_t BLOCK_BYTES = BLOCK_INTS * 4;
+
+
+inline static void reset(uint32_t digest[], std::string& buffer, uint64_t& transforms)
+{
+    /* SHA1 initialization constants */
+    digest[0] = 0x67452301;
+    digest[1] = 0xefcdab89;
+    digest[2] = 0x98badcfe;
+    digest[3] = 0x10325476;
+    digest[4] = 0xc3d2e1f0;
+
+    /* Reset counters */
+    buffer = "";
+    transforms = 0;
+}
+
+
+inline static uint32_t rol(const uint32_t value, const size_t bits) { return (value << bits) | (value >> (32 - bits)); }
+
+
+inline static uint32_t blk(const uint32_t block[BLOCK_INTS], const size_t i)
+{
+    return rol(block[(i + 13) & 15] ^ block[(i + 8) & 15] ^ block[(i + 2) & 15] ^ block[i], 1);
+}
+
+
+/*
+ * (R0+R1), R2, R3, R4 are the different operations used in SHA1
+ */
+
+inline static void R0(const uint32_t block[BLOCK_INTS], const uint32_t v, uint32_t& w, const uint32_t x, const uint32_t y, uint32_t& z, const size_t i)
+{
+    z += ((w & (x ^ y)) ^ y) + block[i] + 0x5a827999 + rol(v, 5);
+    w = rol(w, 30);
+}
+
+
+inline static void R1(uint32_t block[BLOCK_INTS], const uint32_t v, uint32_t& w, const uint32_t x, const uint32_t y, uint32_t& z, const size_t i)
+{
+    block[i] = blk(block, i);
+    z += ((w & (x ^ y)) ^ y) + block[i] + 0x5a827999 + rol(v, 5);
+    w = rol(w, 30);
+}
+
+
+inline static void R2(uint32_t block[BLOCK_INTS], const uint32_t v, uint32_t& w, const uint32_t x, const uint32_t y, uint32_t& z, const size_t i)
+{
+    block[i] = blk(block, i);
+    z += (w ^ x ^ y) + block[i] + 0x6ed9eba1 + rol(v, 5);
+    w = rol(w, 30);
+}
+
+
+inline static void R3(uint32_t block[BLOCK_INTS], const uint32_t v, uint32_t& w, const uint32_t x, const uint32_t y, uint32_t& z, const size_t i)
+{
+    block[i] = blk(block, i);
+    z += (((w | x) & y) | (w & x)) + block[i] + 0x8f1bbcdc + rol(v, 5);
+    w = rol(w, 30);
+}
+
+
+inline static void R4(uint32_t block[BLOCK_INTS], const uint32_t v, uint32_t& w, const uint32_t x, const uint32_t y, uint32_t& z, const size_t i)
+{
+    block[i] = blk(block, i);
+    z += (w ^ x ^ y) + block[i] + 0xca62c1d6 + rol(v, 5);
+    w = rol(w, 30);
+}
+
+
+/*
+ * Hash a single 512-bit block. This is the core of the algorithm.
+ */
+
+inline static void transform(uint32_t digest[], uint32_t block[BLOCK_INTS], uint64_t& transforms)
+{
+    /* Copy digest[] to working vars */
+    uint32_t a = digest[0];
+    uint32_t b = digest[1];
+    uint32_t c = digest[2];
+    uint32_t d = digest[3];
+    uint32_t e = digest[4];
+
+    /* 4 rounds of 20 operations each. Loop unrolled. */
+    R0(block, a, b, c, d, e, 0);
+    R0(block, e, a, b, c, d, 1);
+    R0(block, d, e, a, b, c, 2);
+    R0(block, c, d, e, a, b, 3);
+    R0(block, b, c, d, e, a, 4);
+    R0(block, a, b, c, d, e, 5);
+    R0(block, e, a, b, c, d, 6);
+    R0(block, d, e, a, b, c, 7);
+    R0(block, c, d, e, a, b, 8);
+    R0(block, b, c, d, e, a, 9);
+    R0(block, a, b, c, d, e, 10);
+    R0(block, e, a, b, c, d, 11);
+    R0(block, d, e, a, b, c, 12);
+    R0(block, c, d, e, a, b, 13);
+    R0(block, b, c, d, e, a, 14);
+    R0(block, a, b, c, d, e, 15);
+    R1(block, e, a, b, c, d, 0);
+    R1(block, d, e, a, b, c, 1);
+    R1(block, c, d, e, a, b, 2);
+    R1(block, b, c, d, e, a, 3);
+    R2(block, a, b, c, d, e, 4);
+    R2(block, e, a, b, c, d, 5);
+    R2(block, d, e, a, b, c, 6);
+    R2(block, c, d, e, a, b, 7);
+    R2(block, b, c, d, e, a, 8);
+    R2(block, a, b, c, d, e, 9);
+    R2(block, e, a, b, c, d, 10);
+    R2(block, d, e, a, b, c, 11);
+    R2(block, c, d, e, a, b, 12);
+    R2(block, b, c, d, e, a, 13);
+    R2(block, a, b, c, d, e, 14);
+    R2(block, e, a, b, c, d, 15);
+    R2(block, d, e, a, b, c, 0);
+    R2(block, c, d, e, a, b, 1);
+    R2(block, b, c, d, e, a, 2);
+    R2(block, a, b, c, d, e, 3);
+    R2(block, e, a, b, c, d, 4);
+    R2(block, d, e, a, b, c, 5);
+    R2(block, c, d, e, a, b, 6);
+    R2(block, b, c, d, e, a, 7);
+    R3(block, a, b, c, d, e, 8);
+    R3(block, e, a, b, c, d, 9);
+    R3(block, d, e, a, b, c, 10);
+    R3(block, c, d, e, a, b, 11);
+    R3(block, b, c, d, e, a, 12);
+    R3(block, a, b, c, d, e, 13);
+    R3(block, e, a, b, c, d, 14);
+    R3(block, d, e, a, b, c, 15);
+    R3(block, c, d, e, a, b, 0);
+    R3(block, b, c, d, e, a, 1);
+    R3(block, a, b, c, d, e, 2);
+    R3(block, e, a, b, c, d, 3);
+    R3(block, d, e, a, b, c, 4);
+    R3(block, c, d, e, a, b, 5);
+    R3(block, b, c, d, e, a, 6);
+    R3(block, a, b, c, d, e, 7);
+    R3(block, e, a, b, c, d, 8);
+    R3(block, d, e, a, b, c, 9);
+    R3(block, c, d, e, a, b, 10);
+    R3(block, b, c, d, e, a, 11);
+    R4(block, a, b, c, d, e, 12);
+    R4(block, e, a, b, c, d, 13);
+    R4(block, d, e, a, b, c, 14);
+    R4(block, c, d, e, a, b, 15);
+    R4(block, b, c, d, e, a, 0);
+    R4(block, a, b, c, d, e, 1);
+    R4(block, e, a, b, c, d, 2);
+    R4(block, d, e, a, b, c, 3);
+    R4(block, c, d, e, a, b, 4);
+    R4(block, b, c, d, e, a, 5);
+    R4(block, a, b, c, d, e, 6);
+    R4(block, e, a, b, c, d, 7);
+    R4(block, d, e, a, b, c, 8);
+    R4(block, c, d, e, a, b, 9);
+    R4(block, b, c, d, e, a, 10);
+    R4(block, a, b, c, d, e, 11);
+    R4(block, e, a, b, c, d, 12);
+    R4(block, d, e, a, b, c, 13);
+    R4(block, c, d, e, a, b, 14);
+    R4(block, b, c, d, e, a, 15);
+
+    /* Add the working vars back into digest[] */
+    digest[0] += a;
+    digest[1] += b;
+    digest[2] += c;
+    digest[3] += d;
+    digest[4] += e;
+
+    /* Count the number of transformations */
+    transforms++;
+}
+
+
+inline static void buffer_to_block(const std::string& buffer, uint32_t block[BLOCK_INTS])
+{
+    /* Convert the std::string (byte buffer) to a uint32_t array (MSB) */
+    for (size_t i = 0; i < BLOCK_INTS; i++)
+    {
+        block[i] = (buffer[4 * i + 3] & 0xff) | (buffer[4 * i + 2] & 0xff) << 8 | (buffer[4 * i + 1] & 0xff) << 16 | (buffer[4 * i + 0] & 0xff) << 24;
+    }
+}
+
+
+inline SHA1::SHA1() { reset(digest, buffer, transforms); }
+
+
+inline void SHA1::update(const std::string& s)
+{
+    std::istringstream is(s);
+    update(is);
+}
+
+
+inline void SHA1::update(std::istream& is)
+{
+    while (true)
+    {
+        char sbuf[BLOCK_BYTES];
+        is.read(sbuf, BLOCK_BYTES - buffer.size());
+        buffer.append(sbuf, (std::size_t)is.gcount());
+        if (buffer.size() != BLOCK_BYTES)
+        {
+            return;
+        }
+        uint32_t block[BLOCK_INTS];
+        buffer_to_block(buffer, block);
+        transform(digest, block, transforms);
+        buffer.clear();
+    }
+}
+
+
+/*
+ * Add padding and return the message digest.
+ */
+
+inline std::string SHA1::final()
+{
+    /* Total number of hashed bits */
+    uint64_t total_bits = (transforms * BLOCK_BYTES + buffer.size()) * 8;
+
+    /* Padding */
+    buffer += (char)0x80;
+    size_t orig_size = buffer.size();
+    while (buffer.size() < BLOCK_BYTES)
+    {
+        buffer += (char)0x00;
+    }
+
+    uint32_t block[BLOCK_INTS];
+    buffer_to_block(buffer, block);
+
+    if (orig_size > BLOCK_BYTES - 8)
+    {
+        transform(digest, block, transforms);
+        for (size_t i = 0; i < BLOCK_INTS - 2; i++)
+        {
+            block[i] = 0;
+        }
+    }
+
+    /* Append total_bits, split this uint64_t into two uint32_t */
+    block[BLOCK_INTS - 1] = (uint32_t)total_bits;
+    block[BLOCK_INTS - 2] = (uint32_t)(total_bits >> 32);
+    transform(digest, block, transforms);
+
+    /* Hex std::string */
+    std::ostringstream result;
+    for (size_t i = 0; i < sizeof(digest) / sizeof(digest[0]); i++)
+    {
+        result << std::hex << std::setfill('0') << std::setw(8);
+        result << digest[i];
+    }
+
+    /* Reset for next run */
+    reset(digest, buffer, transforms);
+
+    return result.str();
+}
+
+
+inline std::string SHA1::from_file(const std::string& filename)
+{
+    std::ifstream stream(filename.c_str(), std::ios::binary);
+    SHA1 checksum;
+    checksum.update(stream);
+    return checksum.final();
+}
+
+}
+}
+
+TEST("cc::hash sha1")
+{
+    CHECK(cc::make_hash_sha1_string("") == "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    CHECK(cc::make_hash_sha1_string("The quick brown fox jumps over the lazy dog") == "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12");
+    CHECK(cc::make_hash_sha1_string("The quick brown fox jumps over the lazy cog") == "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b3");
+    CHECK(cc::make_hash_sha1_string("Apfel") == "df589122eac0f6a7bd8795436e692e3675cadc3b");
+}
+
+TEST("cc::hash sha1 comparison vog")
+{
+    vog::SHA1 checksum;
+    checksum.update("");
+    auto hash = checksum.final();
+
+    CHECK(cc::make_hash_sha1_string("") == hash);
+}
+
+APP("cc::make_hash_sha1 vs vog performance")
+{
+    tg::rng rng;
+    cc::vector<std::string> strings;
+    uint64_t total_bytes = 0;
+    for (auto i = 0; i < 10000; ++i)
+    {
+        auto& s = strings.emplace_back();
+        auto l = uniform(rng, 0, 10);
+        for (auto i = 0; i < l; ++i)
+            s += char(' ' + uniform(rng, 0, 90));
+        total_bytes += s.size();
+    }
+
+    cc::vector<std::string> hashes_vog;
+    cc::vector<cc::array<std::byte, 20>> hashes_cc;
+    hashes_vog.resize(strings.size());
+    hashes_cc.resize(strings.size());
+
+    {
+        ct::cycler c;
+        for (auto i : cc::indices_of(strings))
+        {
+            vog::SHA1 checksum;
+            checksum.update(strings[i]);
+            hashes_vog[i] = checksum.final();
+        }
+        LOG("vog: %.2f cycles per byte", c.elapsed_cycles() / double(total_bytes));
+    }
+    {
+        ct::cycler c;
+        for (auto i : cc::indices_of(strings))
+            hashes_cc[i] = cc::make_hash_sha1(strings[i]);
+        LOG(" cc: %.2f cycles per byte", c.elapsed_cycles() / double(total_bytes));
+    }
+}
+
+FUZZ_TEST("cc::hash sha1 vs vog")(tg::rng& rng)
+{
+    auto l = uniform(rng, 0, 100);
+    cc::string s;
+    for (auto i = 0; i < l; ++i)
+        s += char(' ' + uniform(rng, 0, 90));
+
+    vog::SHA1 checksum;
+    checksum.update(s.c_str());
+    auto hash = checksum.final();
+
+    CHECK(cc::make_hash_sha1_string(s) == hash);
+}

--- a/tests/hash.sha1.cc
+++ b/tests/hash.sha1.cc
@@ -2,7 +2,9 @@
 #include <nexus/fuzz_test.hh>
 #include <nexus/test.hh>
 
+#ifdef HAS_CTRACER
 #include <ctracer/trace.hh>
+#endif
 
 #include <rich-log/log.hh>
 
@@ -333,6 +335,7 @@ TEST("cc::hash sha1 comparison vog")
     CHECK(cc::make_hash_sha1_string("") == hash);
 }
 
+#ifdef HAS_CTRACER
 APP("cc::make_hash_sha1 vs vog performance")
 {
     tg::rng rng;
@@ -369,6 +372,7 @@ APP("cc::make_hash_sha1 vs vog performance")
         LOG(" cc: %.2f cycles per byte", c.elapsed_cycles() / double(total_bytes));
     }
 }
+#endif
 
 FUZZ_TEST("cc::hash sha1 vs vog")(tg::rng& rng)
 {

--- a/tests/span.cc
+++ b/tests/span.cc
@@ -7,7 +7,9 @@
 #include <clean-core/string_view.hh>
 #include <clean-core/vector.hh>
 
+#ifdef HAS_CLEAN_RANGES
 #include <clean-ranges/range.hh>
+#endif
 
 static_assert(std::is_trivially_copyable_v<cc::span<int>>);
 
@@ -60,13 +62,19 @@ TEST("cc::span")
 
     s = v;
     CHECK(s.size() == 3);
+#ifdef HAS_CLEAN_RANGES
     CHECK(cr::range(s) == cc::vector{1, 2, 3});
+#endif
 
     s = s.first(2);
+#ifdef HAS_CLEAN_RANGES
     CHECK(cr::range(s) == cc::vector{1, 2});
+#endif
 
     s = cc::span(v).last(2);
+#ifdef HAS_CLEAN_RANGES
     CHECK(cr::range(s) == cc::vector{2, 3});
+#endif
 
     auto b = cc::span(v).as_bytes();
     CHECK(b.size() == 3 * sizeof(int));

--- a/tests/strided_span.cc
+++ b/tests/strided_span.cc
@@ -3,7 +3,9 @@
 #include <clean-core/strided_span.hh>
 #include <clean-core/vector.hh>
 
+#ifdef HAS_CLEAN_RANGES
 #include <clean-ranges/range.hh>
+#endif
 
 TEST("cc::strided_span (span equivalent)")
 {
@@ -49,6 +51,8 @@ TEST("cc::strided_span (span equivalent)")
 
     s = v;
     CHECK(s.size() == 3);
+
+#ifdef HAS_CLEAN_RANGES
     CHECK(cr::range(s) == cc::vector{1, 2, 3});
     CHECK(cr::range(s.reversed()) == cc::vector{3, 2, 1});
 
@@ -57,4 +61,5 @@ TEST("cc::strided_span (span equivalent)")
 
     s = cc::strided_span(v).last(2);
     CHECK(cr::range(s) == cc::vector{2, 3});
+#endif
 }

--- a/tests/values.cc
+++ b/tests/values.cc
@@ -179,4 +179,6 @@ MONTE_CARLO_TEST("value mct")
 
     // TODO: more
     addType(cc::make_box<int>());
+
+	CHECK(true);
 }

--- a/tests/variant.cc
+++ b/tests/variant.cc
@@ -1,0 +1,23 @@
+#include <nexus/test.hh>
+
+#include <clean-core/variant.hh>
+
+TEST("cc::variant basics")
+{
+    cc::variant<int, cc::string, char> v;
+    CC_ASSERT(v == 0);
+    // CC_ASSERT(v != '\0'); -- TODO: what behavior is desired here?
+    CC_ASSERT(v.is<int>());
+    CC_ASSERT(!v.is<char>());
+    CC_ASSERT(v.get<int>() == 0);
+
+    v = 'c';
+    CC_ASSERT(v == 'c');
+    // CC_ASSERT(v != int('c')); -- TODO: what behavior is desired here?
+    CC_ASSERT(v.is<char>());
+    CC_ASSERT(!v.is<int>());
+    CC_ASSERT(v.get<char>() == 'c');
+
+    v = cc::string("hello");
+    CHECK(v == "hello");
+}


### PR DESCRIPTION
Contains all of pt/develop, plus:
- Resolved merge conflicts with develop in range_ref.hh
- Fixed natvis for cc::vector
- v2 of cc::allocator API (no `old_size` in realloc, msize equivalent, names, try_ versions)
- new cc::mpmc_queue in experimental
- Made ctracer and clean-ranges optional in tests
- Fixes to some compiler warnings
- Fix compilation of pimpl.hh, move it to experimental (closes #167 )